### PR TITLE
Feature/camera stability v2

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,6 +1,6 @@
 // main.js
 
-import { app, BrowserWindow, ipcMain, Menu, Tray } from 'electron'; // <-- Добавлен Menu, Tray
+import { app, BrowserWindow, ipcMain, Menu, Tray, Notification } from 'electron'; // <-- Добавлен Menu, Tray
 import path from 'path';
 import { fileURLToPath } from 'url';
 // Импорт yandex-api.js
@@ -25,6 +25,20 @@ const ACCOUNT_NAME_X_TOKEN = 'YandexXToken';
 const getStoredXToken = () => keytar.getPassword(SERVICE_NAME, ACCOUNT_NAME_X_TOKEN);
 const setStoredXToken = (xToken) => keytar.setPassword(SERVICE_NAME, ACCOUNT_NAME_X_TOKEN, xToken);
 const deleteStoredXToken = () => keytar.deletePassword(SERVICE_NAME, ACCOUNT_NAME_X_TOKEN);
+
+/** Coalesce concurrent identical API calls so retry counters are not reset. */
+const inflightRequests = new Map();
+
+const runSingleFlight = (key, fn) => {
+    if (inflightRequests.has(key)) {
+        return inflightRequests.get(key);
+    }
+    const promise = fn().finally(() => {
+        inflightRequests.delete(key);
+    });
+    inflightRequests.set(key, promise);
+    return promise;
+};
 
 const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
 const DEV_VITE_URL = process.env.VITE_DEV_SERVER_URL || 'http://localhost:5173';
@@ -274,31 +288,44 @@ if (!gotTheLock) {
 
     // Когда Electron готов
     app.whenReady().then(() => {
+        if (process.platform === 'win32') {
+            app.setAppUserModelId('com.onegamerstory.smarthomecontrol');
+        }
+
         Menu.setApplicationMenu(null);
 
         createWindow();
         createTray(); // Создаем Tray
-        
-        ipcMain.handle('yandex-api:fetchUserInfo', async (event, token) => {
-            try {
-                return await yandexApi.fetchUserInfo(token, makeRetryCallback('fetchUserInfo'));
-            } catch (error) {
-                throw new Error(error.message, { cause: error });
-            }
-        });
 
         const makeRetryCallback = (action) => {
             return (attempt, maxAttempts) => {
                 if (mainWindow && !mainWindow.isDestroyed()) {
                     mainWindow.webContents.send('yandex-api:retry-attempt', {
+                        action,
                         attempt,
                         maxAttempts,
-                        message: `Попытка повторного подключения ${attempt} из ${maxAttempts}...`
+                        message: `Попытка повторного подключения ${attempt} из ${maxAttempts}...`,
                     });
                 }
                 console.log(`${action}: повторная попытка ${attempt}/${maxAttempts}...`);
             };
         };
+
+        ipcMain.handle('yandex-api:fetchUserInfo', async (event, token, options = {}) => {
+            const retry = options.retry !== false;
+            const key = `fetchUserInfo:${token}:${retry}`;
+            try {
+                return await runSingleFlight(key, () =>
+                    yandexApi.fetchUserInfo(
+                        token,
+                        retry ? makeRetryCallback('fetchUserInfo') : null,
+                        { retry },
+                    ),
+                );
+            } catch (error) {
+                throw new Error(error.message, { cause: error });
+            }
+        });
 
         ipcMain.handle('yandex-api:executeScenario', async (event, token, scenarioId) => {
             try {
@@ -377,13 +404,22 @@ if (!gotTheLock) {
             }
         });
 
-        ipcMain.handle('yandex-api:getQuasarCameraDevice', async (event, deviceId) => {
+        ipcMain.handle('yandex-api:getQuasarCameraDevice', async (event, deviceId, options = {}) => {
+            const retry = options.retry !== false;
             try {
                 const xToken = await getStoredXToken();
                 if (!xToken) {
                     throw new Error('X_TOKEN_REQUIRED');
                 }
-                return await yandexApi.getQuasarCameraDevice(xToken, deviceId, makeRetryCallback('getQuasarCameraDevice'));
+                const key = `getQuasarCameraDevice:${deviceId}:${retry}`;
+                return await runSingleFlight(key, () =>
+                    yandexApi.getQuasarCameraDevice(
+                        xToken,
+                        deviceId,
+                        retry ? makeRetryCallback('getQuasarCameraDevice') : null,
+                        { retry },
+                    ),
+                );
             } catch (error) {
                 if (error.message?.includes('Quasar auth') || error.message?.includes('x-token')) {
                     await deleteStoredXToken();
@@ -458,6 +494,37 @@ if (!gotTheLock) {
                 openAsHidden: false, // Можно изменить на true, если нужно запускать скрыто
             });
             return enabled;
+        });
+
+        ipcMain.handle('notification:camera-stream-error', async (_event, { deviceId, deviceName, message }) => {
+            if (!Notification.isSupported()) {
+                return false;
+            }
+
+            const notification = new Notification({
+                title: `${deviceName} — нет видео`,
+                body: message,
+                actions: [{ type: 'button', text: 'Повторить' }],
+                closeButtonText: 'Закрыть',
+            });
+
+            notification.on('action', () => {
+                if (mainWindow && !mainWindow.isDestroyed()) {
+                    mainWindow.show();
+                    mainWindow.focus();
+                    mainWindow.webContents.send('camera-stream:retry', { deviceId });
+                }
+            });
+
+            notification.on('click', () => {
+                if (mainWindow && !mainWindow.isDestroyed()) {
+                    mainWindow.show();
+                    mainWindow.focus();
+                }
+            });
+
+            notification.show();
+            return true;
         });
         
         // --- 2. НОВЫЙ IPC-ОБРАБОТЧИК ДЛЯ ПОЛУЧЕНИЯ ИЗБРАННЫХ ЭЛЕМЕНТОВ ---

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -3,7 +3,7 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('api', {
-    fetchUserInfo: (token) => ipcRenderer.invoke('yandex-api:fetchUserInfo', token),
+    fetchUserInfo: (token, options) => ipcRenderer.invoke('yandex-api:fetchUserInfo', token, options),
     executeScenario: (token, scenarioId) => ipcRenderer.invoke('yandex-api:executeScenario', token, scenarioId),
     toggleDevice: (token, deviceId, newState) => ipcRenderer.invoke('yandex-api:toggleDevice', token, deviceId, newState),
     toggleGroup: (token, groupId, deviceIds, newState) => ipcRenderer.invoke('yandex-api:toggleGroup', token, groupId, deviceIds, newState),
@@ -12,7 +12,7 @@ contextBridge.exposeInMainWorld('api', {
     getCameraStream: (deviceId) => ipcRenderer.invoke('yandex-api:getCameraStream', deviceId),
     setCameraPrivacyMode: (deviceId, privacyEnabled, toggleInstance) =>
         ipcRenderer.invoke('yandex-api:setCameraPrivacyMode', deviceId, privacyEnabled, toggleInstance),
-    getQuasarCameraDevice: (deviceId) => ipcRenderer.invoke('yandex-api:getQuasarCameraDevice', deviceId),
+    getQuasarCameraDevice: (deviceId, options) => ipcRenderer.invoke('yandex-api:getQuasarCameraDevice', deviceId, options),
 
     hasXToken: () => ipcRenderer.invoke('yandex-auth:hasXToken'),
     startQrAuth: () => ipcRenderer.invoke('yandex-auth:startQr'),
@@ -52,5 +52,13 @@ contextBridge.exposeInMainWorld('api', {
         ipcRenderer.on('yandex-api:retry-attempt', handler);
         // Возвращаем функцию для отписки
         return () => ipcRenderer.removeListener('yandex-api:retry-attempt', handler);
-    }
+    },
+
+    showCameraStreamErrorNotification: (payload) =>
+        ipcRenderer.invoke('notification:camera-stream-error', payload),
+    onCameraStreamRetry: (callback) => {
+        const handler = (_event, data) => callback(data);
+        ipcRenderer.on('camera-stream:retry', handler);
+        return () => ipcRenderer.removeListener('camera-stream:retry', handler);
+    },
 });

--- a/electron/yandex-api.js
+++ b/electron/yandex-api.js
@@ -83,26 +83,31 @@ const withRetry = async (asyncFn, onRetryAttempt = null) => {
     throw lastError;
 };
 
-// 1. Получение информации о пользователе
-export const fetchUserInfo = async (token, onRetryAttempt = null) => {
-    return withRetry(async () => {
-        const response = await fetch(`${BASE_URL}/user/info`, {
-            method: 'GET',
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json',
-            },
-        });
+const fetchUserInfoOnce = async (token) => {
+    const response = await fetch(`${BASE_URL}/user/info`, {
+        method: 'GET',
+        headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json',
+        },
+    });
 
-        if (!response.ok) {
-            if (response.status === 401 || response.status === 403) {
-                throw new Error('Ошибка авторизации. Проверьте ваш токен.');
-            }
-            throw new Error(`Не удалось загрузить список устройств. Попробуйте позже.`);
+    if (!response.ok) {
+        if (response.status === 401 || response.status === 403) {
+            throw new Error('Ошибка авторизации. Проверьте ваш токен.');
         }
+        throw new Error(`Ошибка загрузки данных: ${response.status} ${response.statusText}`);
+    }
 
-        return await response.json();
-    }, onRetryAttempt);
+    return await response.json();
+};
+
+// 1. Получение информации о пользователе
+export const fetchUserInfo = async (token, onRetryAttempt = null, { retry = true } = {}) => {
+    if (!retry) {
+        return fetchUserInfoOnce(token);
+    }
+    return withRetry(() => fetchUserInfoOnce(token), onRetryAttempt);
 };
 
 // 1.1 Получение информации об устройстве по ID
@@ -120,7 +125,7 @@ export const fetchDevice = async (token, deviceId, onRetryAttempt = null) => {
             if (response.status === 401 || response.status === 403) {
                 throw new Error('Ошибка авторизации. Проверьте ваш токен.');
             }
-            throw new Error(`Не удалось загрузить данные устройства`);
+            throw new Error(`Не удалось получить устройство ${deviceId}: ${response.status} ${response.statusText}`);
         }
 
         return await response.json();
@@ -139,7 +144,7 @@ export const executeScenario = async (token, scenarioId, onRetryAttempt = null) 
         });
 
         if (!response.ok) {
-            throw new Error(`Не удалось запустить сценарий. Попробуйте позже.`);
+            throw new Error(`Не удалось запустить сценарий: ${response.status}`);
         }
     }, onRetryAttempt);
 };
@@ -174,13 +179,13 @@ export const toggleDevice = async (token, deviceId, newState, onRetryAttempt = n
         });
 
         if (!response.ok) {
-            throw new Error(`Не удалось переключить устройство. Попробуйте позже.`);
+            throw new Error(`Не удалось изменить состояние устройства: ${response.status}`);
         }
         
         const data = await response.json();
         const deviceResult = data.devices?.find((d) => d.id === deviceId);
         if (deviceResult && 'error_code' in deviceResult) {
-            throw new Error(`Не удалось переключить устройство. Попробуйте позже.`);
+            throw new Error(`Ошибка устройства: ${deviceResult.error_message || deviceResult.error_code}`);
         }
     }, onRetryAttempt);
 };
@@ -254,13 +259,13 @@ export const setDeviceMode = async (token, deviceId, modeActions, turnOn = false
         });
 
         if (!response.ok) {
-            throw new Error(`Не удалось изменить настройки устройства. Попробуйте позже.`);
+            throw new Error(`Не удалось изменить режим устройства: ${response.status}`);
         }
         
         const data = await response.json();
         const deviceResult = data.devices?.find((d) => d.id === deviceId);
         if (deviceResult && 'error_code' in deviceResult) {
-            throw new Error(`Не удалось изменить настройки устройства. Попробуйте позже.`);
+            throw new Error(`Ошибка устройства: ${deviceResult.error_message || deviceResult.error_code}`);
         }
     }, onRetryAttempt);
 };
@@ -297,13 +302,14 @@ export const toggleGroup = async (token, groupId, deviceIds, newState, onRetryAt
         });
 
         if (!response.ok) {
-            throw new Error(`Не удалось переключить группу. Попробуйте позже.`);
+            throw new Error(`Не удалось переключить группу: ${response.status}`);
         }
 
         const data = await response.json();
         const errors = (data.devices || []).filter(d => 'error_code' in d);
         if (errors.length > 0) {
-            throw new Error(`Не удалось переключить группу. Попробуйте позже.`);
+            const firstError = errors[0];
+            throw new Error(`Ошибка устройства: ${firstError.error_message || firstError.error_code}`);
         }
     }, onRetryAttempt);
 };
@@ -337,19 +343,23 @@ const sendIotDeviceAction = async (token, deviceId, action, onRetryAttempt = nul
         });
 
         if (!response.ok) {
-            throw new Error(`Не удалось изменить параметр. Попробуйте позже.`);
+            throw new Error(`Не удалось изменить параметр устройства: ${response.status}`);
         }
 
         const data = await response.json();
         const deviceResult = data.devices?.find((d) => d.id === deviceId);
         if (deviceResult && 'error_code' in deviceResult) {
-            throw new Error(`Не удалось изменить параметр. Попробуйте позже.`);
+            throw new Error(deviceResult.error_message || deviceResult.error_code);
         }
     }, onRetryAttempt);
 };
 
-export const getQuasarCameraDevice = async (xToken, deviceId, onRetryAttempt = null) => {
-    return withRetry(async () => getQuasarDevice(xToken, deviceId), onRetryAttempt);
+export const getQuasarCameraDevice = async (xToken, deviceId, onRetryAttempt = null, { retry = true } = {}) => {
+    const fn = () => getQuasarDevice(xToken, deviceId);
+    if (!retry) {
+        return fn();
+    }
+    return withRetry(fn, onRetryAttempt);
 };
 
 export const setCameraPrivacyMode = async (

--- a/electron/yandex-quasar.js
+++ b/electron/yandex-quasar.js
@@ -41,7 +41,7 @@ const getQuasarSession = async (xToken) => {
     const passportHost = auth.passport_host?.replace(/\/$/, '');
     const trackId = auth.track_id;
     if (!passportHost || !trackId) {
-        throw new Error('Ошибка авторизации Quasar: неполный ответ сервера');
+        throw new Error('Quasar auth: неполный ответ passport');
     }
 
     const sessionResponse = await quasarFetch(`${passportHost}/auth/session/?track_id=${trackId}`, {
@@ -50,14 +50,14 @@ const getQuasarSession = async (xToken) => {
 
     const location = sessionResponse.headers.get('location') || '';
     if (!location.includes('/auth/finish')) {
-        throw new Error('Ошибка авторизации Quasar: не удалось установить сессию');
+        throw new Error('Quasar auth: не удалось установить сессию passport');
     }
 
     const storageResponse = await quasarFetch('https://yandex.ru/quasar?storage=1');
     const storage = await storageResponse.json();
     const uid = storage?.storage?.user?.uid;
     if (!uid) {
-        throw new Error('Ошибка авторизации Quasar: сессия не подтверждена');
+        throw new Error('Quasar auth: сессия не подтверждена (нет uid)');
     }
 
     const quasarPage = await quasarFetch('https://yandex.ru/quasar');
@@ -65,7 +65,7 @@ const getQuasarSession = async (xToken) => {
     const csrf = extractCsrfToken(html);
 
     if (!csrf) {
-        throw new Error('Ошибка авторизации Quasar: не удалось получить токен');
+        throw new Error('Не удалось получить CSRF-токен Quasar');
     }
 
     const session = { fetch: quasarFetch, csrf, jar };
@@ -78,7 +78,7 @@ const refreshCsrf = async (session) => {
     const html = await quasarPage.text();
     const csrf = extractCsrfToken(html);
     if (!csrf) {
-        throw new Error('Ошибка авторизации Quasar: не удалось обновить токен');
+        throw new Error('Не удалось обновить CSRF-токен Quasar');
     }
     session.csrf = csrf;
     return csrf;
@@ -88,11 +88,11 @@ const parseStreamFromDevices = (devices, deviceId) => {
     const device = devices?.find((item) => item.id === deviceId) ?? devices?.[0];
 
     if (!device) {
-        throw new Error('Камера не найдена');
+        throw new Error('Камера не найдена в ответе Quasar API');
     }
 
     if (device.error_code) {
-        throw new Error('Ошибка получения видеопотока');
+        throw new Error(device.error_message || device.error_code);
     }
 
     const capability = (device.capabilities || []).find(
@@ -105,14 +105,14 @@ const parseStreamFromDevices = (devices, deviceId) => {
 
     const actionResult = capability.state.action_result;
     if (actionResult?.status === 'ERROR') {
-        throw new Error('Не удалось получить видеопоток');
+        throw new Error(actionResult.error_message || actionResult.error_code || 'Не удалось получить видеопоток');
     }
 
     const streamUrl = capability.state.value?.stream_url;
     const protocol = capability.state.value?.protocol || 'hls';
 
     if (!streamUrl) {
-        throw new Error('Не удалось получить видеопоток');
+        throw new Error('URL видеопотока не получен');
     }
 
     return { streamUrl, protocol };
@@ -153,13 +153,13 @@ const requestHlsStream = async (xToken, deviceId) => {
     });
 
     if (!response.ok) {
-        throw new Error(`Не удалось получить видеопоток. Попробуйте позже.`);
+        throw new Error(`Quasar API: ${response.status} ${response.statusText}`);
     }
 
     const data = await response.json();
 
     if (data.status !== 'ok') {
-        throw new Error('Не удалось получить видеопоток');
+        throw new Error(data.message || data.text || 'Ошибка Quasar API при запросе видеопотока');
     }
 
     return parseStreamFromDevices(data.devices, deviceId);
@@ -182,7 +182,7 @@ const requestWebrtcRoom = async (xToken, deviceId) => {
 
     if (!response.ok) {
         console.error(`[Camera] create-room HTTP error: ${response.status} ${response.statusText}`);
-        throw new Error(`Не удалось получить видеопоток. Попробуйте позже.`);
+        throw new Error(`Quasar WebRTC: ${response.status} ${response.statusText}`);
     }
 
     const data = await response.json();
@@ -201,7 +201,7 @@ const requestWebrtcRoom = async (xToken, deviceId) => {
     const result = data.result;
 
     if (!result?.service_url) {
-        throw new Error('Не удалось получить видеопоток');
+        throw new Error(data.message || data.text || 'Не удалось создать WebRTC-комнату');
     }
 
     return {
@@ -267,19 +267,19 @@ export const getQuasarDevice = async (xToken, deviceId) => {
 
     const detailResponse = await session.fetch(`${QUASAR_ACTIONS_URL}/${deviceId}`);
     if (!detailResponse.ok) {
-        throw new Error('Ошибка загрузки данных камеры');
+        throw new Error(`Quasar API: ${detailResponse.status} ${detailResponse.statusText}`);
     }
 
     const detailData = await detailResponse.json();
     if (detailData.status !== 'ok') {
-        throw new Error('Ошибка загрузки данных камеры');
+        throw new Error(detailData.message || detailData.text || 'Ошибка Quasar API');
     }
 
     if (detailData.id === deviceId) {
         return detailData;
     }
 
-    throw new Error('Камера не найдена');
+    throw new Error('Камера не найдена в Quasar API');
 };
 
 export const buildPrivacyActionCandidates = (quasarDevice, privacyEnabled, toggleInstance = 'privacy') => {
@@ -368,20 +368,20 @@ const postQuasarDeviceActions = async (session, deviceId, actions) => {
     for (const url of urls) {
         const response = await session.fetch(url, { method: 'POST', headers, body });
         if (!response.ok) {
-            lastError = new Error('Не удалось выполнить действие. Попробуйте позже.');
+            lastError = new Error(`Quasar API: ${response.status} ${response.statusText}`);
             continue;
         }
 
         const data = await response.json();
         console.log(`[Quasar] ${url.includes('v3') ? 'v3' : 'v1'} response:`, JSON.stringify(data).slice(0, 400));
         if (data.status !== 'ok') {
-            lastError = new Error('Не удалось выполнить действие');
+            lastError = new Error(data.message || data.text || 'Ошибка Quasar API');
             continue;
         }
 
         const device = data.devices?.find((item) => item.id === deviceId) ?? data.devices?.[0];
         if (device?.error_code) {
-            lastError = new Error('Не удалось выполнить действие');
+            lastError = new Error(device.error_message || device.error_code);
             continue;
         }
 

--- a/src/components/modals/CameraStreamModal.tsx
+++ b/src/components/modals/CameraStreamModal.tsx
@@ -1,28 +1,16 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Hls from 'hls.js';
 import { YandexDevice, CameraStreamResult, YandexWebRtcRoom } from '../../types/index';
-import { connectYandexGoloomWebRtc, GoloomConnection, JWT_FAST_REUSE_MIN_TTL_MS } from '../../services/yandexGoloomWebRtc';
+import { connectYandexGoloomWebRtc, GoloomConnection, waitForVideoFrame, TOO_MANY_PEERS_RETRY_MS } from '../../services/yandexGoloomWebRtc';
 
-/** Returns false if the room JWT is expired or will expire soon (fast-path unsafe). */
-const isRoomCredentialFresh = (room: YandexWebRtcRoom): boolean => {
-  try {
-    const b64 = room.credentials.split('.')[1]?.replace(/-/g, '+').replace(/_/g, '/');
-    if (!b64) return true;
-    const payload = JSON.parse(atob(b64)) as Record<string, unknown>;
-    if (typeof payload.exp !== 'number') return true;
-    return payload.exp * 1000 > Date.now() + JWT_FAST_REUSE_MIN_TTL_MS;
-  } catch {
-    return true;
-  }
-};
 import { getQuasarCameraDevice } from '../../services/yandexIoT';
-import { cleanErrorMessage } from '../../utils/errors';
 import {
   hasCameraPrivacyControl,
   isCameraPrivacyModeEnabled,
   mergeCameraDeviceState,
   getCameraPrivacyInstance,
 } from '../../constants';
+import { attachVideoAudioBoost, VideoAudioBoost } from '../../utils/videoAudioBoost';
 import { X, RefreshCw, Loader2, Video, AlertCircle, Eye, EyeOff, Maximize2, Settings2, PictureInPicture2 } from 'lucide-react';
 
 const QUALITY_PRESETS = [
@@ -30,6 +18,25 @@ const QUALITY_PRESETS = [
   { label: 'Low', width: 848,  height: 480  },
 ] as const;
 type QualityPreset = typeof QUALITY_PRESETS[number];
+
+const MAX_STREAM_RETRIES = 10;
+const STREAM_RETRY_DELAY_MS = 3000;
+
+const normalizeStreamErrorMessage = (err: unknown): string => {
+  const raw = err instanceof Error ? err.message : 'Не удалось получить видеопоток';
+  const marker = 'Error: ';
+  const idx = raw.lastIndexOf(marker);
+  return idx >= 0 ? raw.slice(idx + marker.length) : raw;
+};
+
+const isNonRetryableStreamError = (message: string): boolean =>
+  message.includes('приват')
+  || message.includes('не умеет')
+  || message.includes('X_TOKEN')
+  || message.includes('Quasar auth')
+  || message.includes('Требуется вход')
+  || message.includes('QR')
+  || message.includes('Камера не найдена');
 
 interface CameraStreamModalProps {
   device: YandexDevice;
@@ -49,21 +56,34 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
   onPrivacyChanged,
 }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const stagingVideoRef = useRef<HTMLVideoElement>(null);
   const hlsRef = useRef<Hls | null>(null);
   const webrtcConnectionRef = useRef<GoloomConnection | null>(null);
   const loadStreamRef = useRef<((silent?: boolean) => void) | null>(null);
   const lastWebrtcRoomRef = useRef<import('../../types/index').YandexWebRtcRoom | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const credentialRefreshInFlightRef = useRef(false);
+  const activeConnectionIdRef = useRef<string | null>(null);
+  const scheduleReconnectRef = useRef<() => void>(() => {});
+  const performSeamlessCredentialRefreshRef = useRef<(cleanupOld: () => void, connectionId: string) => boolean>(() => false);
+  const refreshInFlightRef = useRef<Promise<YandexDevice> | null>(null);
+  /** Incremented on close/unmount — async work must match to continue. */
+  const sessionRef = useRef(0);
+  const pendingTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+  const streamRetryCountRef = useRef(0);
+  const audioBoostRef = useRef<VideoAudioBoost | null>(null);
   const qualityMenuRef = useRef<HTMLDivElement>(null);
   const freezeCanvasRef = useRef<HTMLCanvasElement>(null);
   const selectedQualityRef = useRef<QualityPreset>(QUALITY_PRESETS[0]);
   const prevPrivacyRef = useRef(false);
+  const cameraDeviceRef = useRef<YandexDevice>(device);
   const [cameraDevice, setCameraDevice] = useState<YandexDevice>(device);
   const [isLoading, setIsLoading] = useState(false);
   const [isTogglingPrivacy, setIsTogglingPrivacy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [streamProtocol, setStreamProtocol] = useState<string | null>(null);
   const [privacyNotice, setPrivacyNotice] = useState<string | null>(null);
+  const [reconnectNotice, setReconnectNotice] = useState<string | null>(null);
   const [selectedQuality, setSelectedQuality] = useState<QualityPreset>(QUALITY_PRESETS[0]);
   const [showQualityMenu, setShowQualityMenu] = useState(false);
   const [isPictureInPicture, setIsPictureInPicture] = useState(false);
@@ -82,23 +102,72 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
     setShowFreezeFrame(true);
   }, []);
 
+  const exitPiPIfActive = useCallback(() => {
+    const video = videoRef.current;
+    if (!video || document.pictureInPictureElement !== video) return;
+    void document.exitPictureInPicture();
+    setIsPictureInPicture(false);
+  }, []);
+
+  /** Black screen in PiP during silent reconnect — do not close the PiP window. */
+  const blankPiPIfVideo = useCallback(() => {
+    const video = videoRef.current;
+    if (!video || document.pictureInPictureElement !== video) return;
+    video.pause();
+    video.srcObject = null;
+    video.removeAttribute('src');
+    void video.load();
+  }, []);
+
   const privacyEnabled = isCameraPrivacyModeEnabled(cameraDevice);
   const showPrivacyButton = hasCameraPrivacyControl(cameraDevice);
 
-  const refreshCameraDevice = useCallback(async () => {
-    try {
-      const quasarDevice = await getQuasarCameraDevice(device.id);
-      setCameraDevice(mergeCameraDeviceState(device, quasarDevice));
-    } catch {
-      setCameraDevice(device);
+  useEffect(() => {
+    cameraDeviceRef.current = cameraDevice;
+  }, [cameraDevice]);
+
+  const PRIVACY_ON_NOTICE = 'Режим приватности включён. Камера не передаёт видео.';
+
+  const isSessionAlive = useCallback((session: number) => session === sessionRef.current, []);
+
+  const clearPendingTimers = useCallback(() => {
+    for (const id of pendingTimersRef.current) {
+      clearTimeout(id);
     }
-  }, [device]);
+    pendingTimersRef.current.clear();
+    reconnectTimerRef.current = null;
+  }, []);
+
+  const scheduleSessionTimer = useCallback((
+    session: number,
+    fn: () => void,
+    delayMs: number,
+  ) => {
+    const id = window.setTimeout(() => {
+      pendingTimersRef.current.delete(id);
+      if (!isSessionAlive(session)) return;
+      fn();
+    }, delayMs);
+    pendingTimersRef.current.add(id);
+    return id;
+  }, [isSessionAlive]);
+
+  const abortStreamSession = useCallback(() => {
+    sessionRef.current += 1;
+    clearPendingTimers();
+    credentialRefreshInFlightRef.current = false;
+    activeConnectionIdRef.current = null;
+    lastWebrtcRoomRef.current = null;
+    loadStreamRef.current = null;
+    streamRetryCountRef.current = 0;
+    performSeamlessCredentialRefreshRef.current = () => false;
+    scheduleReconnectRef.current = () => {};
+  }, [clearPendingTimers]);
 
   const cleanupPlayer = useCallback(() => {
-    if (reconnectTimerRef.current) {
-      clearTimeout(reconnectTimerRef.current);
-      reconnectTimerRef.current = null;
-    }
+    abortStreamSession();
+    audioBoostRef.current?.release();
+    audioBoostRef.current = null;
     if (hlsRef.current) {
       hlsRef.current.destroy();
       hlsRef.current = null;
@@ -117,9 +186,245 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
       videoRef.current.srcObject = null;
       videoRef.current.load();
     }
-  }, []);
+    if (stagingVideoRef.current) {
+      stagingVideoRef.current.srcObject = null;
+    }
+  }, [abortStreamSession]);
+
+  const reportStreamError = useCallback((message: string, options?: { osNotify?: boolean }) => {
+    exitPiPIfActive();
+    const video = videoRef.current;
+    if (video) {
+      video.pause();
+      if (document.pictureInPictureElement === video) {
+        video.srcObject = null;
+      }
+    }
+    setReconnectNotice(null);
+    streamRetryCountRef.current = 0;
+    setError(message);
+    setShowFreezeFrame(false);
+    setIsLoading(false);
+
+    if (options?.osNotify && window.api?.showCameraStreamErrorNotification) {
+      void window.api.showCameraStreamErrorNotification({
+        deviceId: device.id,
+        deviceName: cameraDeviceRef.current.name,
+        message,
+      });
+    }
+  }, [device.id, exitPiPIfActive]);
+
+  const scheduleStreamRetry = useCallback((session: number, message: string) => {
+    if (!isSessionAlive(session)) return;
+
+    streamRetryCountRef.current += 1;
+    if (streamRetryCountRef.current >= MAX_STREAM_RETRIES) {
+      reportStreamError(message, { osNotify: true });
+      return;
+    }
+
+    blankPiPIfVideo();
+    setError(null);
+    setPrivacyNotice(null);
+    setReconnectNotice(
+      `Переподключение… (попытка ${streamRetryCountRef.current}/${MAX_STREAM_RETRIES})`,
+    );
+
+    reconnectTimerRef.current = scheduleSessionTimer(session, () => {
+      reconnectTimerRef.current = null;
+      if (!isSessionAlive(session)) return;
+      loadStreamRef.current?.(true);
+    }, STREAM_RETRY_DELAY_MS);
+  }, [blankPiPIfVideo, isSessionAlive, reportStreamError, scheduleSessionTimer]);
+
+  const enterPrivacyWaitingState = useCallback((silent = false) => {
+    if (!silent) {
+      cleanupPlayer();
+      setError(null);
+      setStreamProtocol(null);
+      setIsLoading(false);
+    }
+    setPrivacyNotice(PRIVACY_ON_NOTICE);
+  }, [cleanupPlayer]);
+
+  const refreshCameraDevice = useCallback(async (options?: { retry?: boolean }): Promise<YandexDevice> => {
+    const session = sessionRef.current;
+    if (refreshInFlightRef.current) {
+      return refreshInFlightRef.current;
+    }
+
+    const task = (async () => {
+      try {
+        const quasarDevice = await getQuasarCameraDevice(device.id, options);
+        if (!isSessionAlive(session)) return device;
+        const merged = mergeCameraDeviceState(device, quasarDevice);
+        setCameraDevice(merged);
+        return merged;
+      } catch {
+        if (!isSessionAlive(session)) return device;
+        if (options?.retry !== false) {
+          setCameraDevice(device);
+        }
+        return device;
+      }
+    })();
+
+    refreshInFlightRef.current = task;
+    try {
+      return await task;
+    } finally {
+      if (refreshInFlightRef.current === task) {
+        refreshInFlightRef.current = null;
+      }
+    }
+  }, [device, isSessionAlive]);
+
+  const performSeamlessCredentialRefresh = useCallback((cleanupOld: () => void, connectionId: string): boolean => {
+    const session = sessionRef.current;
+    if (!isSessionAlive(session)) {
+      cleanupOld();
+      return false;
+    }
+    if (activeConnectionIdRef.current !== connectionId) {
+      cleanupOld();
+      return false;
+    }
+    if (credentialRefreshInFlightRef.current) {
+      cleanupOld();
+      return false;
+    }
+
+    credentialRefreshInFlightRef.current = true;
+    let refreshWatchdog: ReturnType<typeof setTimeout> | null = scheduleSessionTimer(session, () => {
+      if (!credentialRefreshInFlightRef.current) return;
+      credentialRefreshInFlightRef.current = false;
+      lastWebrtcRoomRef.current = null;
+      loadStreamRef.current?.(true);
+    }, 45000);
+
+    const clearRefreshWatchdog = () => {
+      if (refreshWatchdog !== null) {
+        clearTimeout(refreshWatchdog);
+        pendingTimersRef.current.delete(refreshWatchdog);
+        refreshWatchdog = null;
+      }
+    };
+
+    const scheduleReconnectAfterRefreshFailure = () => {
+      if (!isSessionAlive(session)) return;
+      lastWebrtcRoomRef.current = null;
+      scheduleSessionTimer(session, () => loadStreamRef.current?.(true), 3000);
+    };
+
+    void (async () => {
+      let stagingConn: GoloomConnection | null = null;
+      let retryScheduled = false;
+
+      const isTooManyPeers = (err: unknown) =>
+        err instanceof Error && /слишком много|too.?many/i.test(err.message);
+
+      try {
+        const mainVideo = videoRef.current;
+        const stagingVideo = stagingVideoRef.current;
+        if (!mainVideo || !stagingVideo) {
+          cleanupOld();
+          scheduleReconnectAfterRefreshFailure();
+          return;
+        }
+
+        const stream = await onGetStream(device.id);
+        if (!isSessionAlive(session)) {
+          return;
+        }
+        if (stream.protocol !== 'webrtc' || !stream.webrtc) {
+          throw new Error('WebRTC room not available');
+        }
+
+        try {
+          stagingConn = await connectYandexGoloomWebRtc(
+            stream.webrtc,
+            stagingVideo,
+            undefined,
+            selectedQualityRef.current,
+            undefined,
+          );
+        } catch (err) {
+          if (isTooManyPeers(err)) {
+            stagingConn?.cleanup();
+            retryScheduled = true;
+            scheduleSessionTimer(session, () => {
+              credentialRefreshInFlightRef.current = false;
+              void performSeamlessCredentialRefreshRef.current(cleanupOld, connectionId);
+            }, TOO_MANY_PEERS_RETRY_MS);
+            return;
+          }
+          throw err;
+        }
+
+        if (!isSessionAlive(session)) {
+          stagingConn.cleanup();
+          return;
+        }
+
+        await waitForVideoFrame(stagingVideo);
+        if (!isSessionAlive(session)) {
+          stagingConn.cleanup();
+          return;
+        }
+
+        const newStream = stagingVideo.srcObject;
+        if (!newStream) {
+          throw new Error('Staging stream missing after connect');
+        }
+
+        mainVideo.srcObject = newStream;
+        mainVideo.muted = false;
+        try { await mainVideo.play(); } catch { /* ignore */ }
+        stagingVideo.srcObject = null;
+        setShowFreezeFrame(false);
+        setError(null);
+
+        cleanupOld();
+        webrtcConnectionRef.current = stagingConn;
+        activeConnectionIdRef.current = stagingConn.id;
+        stagingConn = null;
+        lastWebrtcRoomRef.current = stream.webrtc;
+      } catch (err) {
+        stagingConn?.cleanup();
+        if (!isSessionAlive(session)) return;
+        if (isTooManyPeers(err)) {
+          retryScheduled = true;
+          scheduleSessionTimer(session, () => {
+            credentialRefreshInFlightRef.current = false;
+            void performSeamlessCredentialRefreshRef.current(cleanupOld, connectionId);
+          }, TOO_MANY_PEERS_RETRY_MS);
+          return;
+        }
+        cleanupOld();
+        activeConnectionIdRef.current = null;
+        scheduleReconnectAfterRefreshFailure();
+      } finally {
+        clearRefreshWatchdog();
+        if (!retryScheduled) {
+          credentialRefreshInFlightRef.current = false;
+        }
+      }
+    })();
+
+    return true;
+  }, [device.id, onGetStream, isSessionAlive, scheduleSessionTimer]);
+
+  useEffect(() => {
+    performSeamlessCredentialRefreshRef.current = performSeamlessCredentialRefresh;
+  }, [performSeamlessCredentialRefresh]);
 
   const loadStream = useCallback(async (silent = false) => {
+    if (isCameraPrivacyModeEnabled(cameraDeviceRef.current)) {
+      enterPrivacyWaitingState(silent);
+      return;
+    }
+
     if (!silent) {
       cleanupPlayer();
       setIsLoading(true);
@@ -127,19 +432,24 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
       setPrivacyNotice(null);
       setStreamProtocol(null);
     } else {
-      // Silent reconnect: capture last frame before tracks are torn down
+      blankPiPIfVideo();
       captureFreezeFrame();
-      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
-      if (hlsRef.current) { hlsRef.current.destroy(); hlsRef.current = null; }
+      clearPendingTimers();
       if (webrtcConnectionRef.current) { webrtcConnectionRef.current.cleanupSoft(); webrtcConnectionRef.current = null; }
-      // Clear stale error so the overlay doesn't stay on top of a recovered stream
-      setError(null);
       setPrivacyNotice(null);
     }
 
+    const session = sessionRef.current;
+    if (!isSessionAlive(session)) return;
+
     try {
       const stream = await onGetStream(device.id);
+      if (!isSessionAlive(session)) return;
+
+      streamRetryCountRef.current = 0;
+      setReconnectNotice(null);
       setStreamProtocol(stream.protocol);
+      setError(null);
 
       const video = videoRef.current;
       if (!video) {
@@ -149,42 +459,33 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
       if (stream.protocol === 'webrtc' && stream.webrtc) {
         lastWebrtcRoomRef.current = stream.webrtc;
 
-        const scheduleReconnect = (forceNewCredentials = false) => {
-          if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
-          if (forceNewCredentials) captureFreezeFrame();
-          const delayMs = forceNewCredentials ? 0 : 3000;
-          reconnectTimerRef.current = setTimeout(async () => {
+        const scheduleReconnect = () => {
+          if (!isSessionAlive(session)) return;
+          reconnectTimerRef.current = scheduleSessionTimer(session, () => {
             reconnectTimerRef.current = null;
-            const v = videoRef.current;
-            if (!v) return;
-            if (forceNewCredentials) {
-              lastWebrtcRoomRef.current = null;
-            }
-            const cached = lastWebrtcRoomRef.current;
-            if (cached && isRoomCredentialFresh(cached)) {
-              if (webrtcConnectionRef.current) { webrtcConnectionRef.current.cleanupSoft(); webrtcConnectionRef.current = null; }
-              try {
-                webrtcConnectionRef.current = await connectYandexGoloomWebRtc(
-                  cached, v, () => scheduleReconnect(false), selectedQualityRef.current,
-                  () => scheduleReconnect(true),
-                );
-                return;
-              } catch (err) {
-                const isBusy = err instanceof Error && /слишком много|too.?many/i.test(err.message);
-                if (isBusy) await new Promise(r => window.setTimeout(r, 3000));
-              }
-            }
+            if (!isSessionAlive(session)) return;
+            lastWebrtcRoomRef.current = null;
             loadStreamRef.current?.(true);
-          }, delayMs);
+          }, 3000);
         };
+        scheduleReconnectRef.current = scheduleReconnect;
 
-        webrtcConnectionRef.current = await connectYandexGoloomWebRtc(
+        const conn = await connectYandexGoloomWebRtc(
           stream.webrtc,
           video,
-          () => scheduleReconnect(false),
+          () => scheduleReconnect(),
           selectedQualityRef.current,
-          () => scheduleReconnect(true),
+          (oldCleanup, connId) => {
+            if (!isSessionAlive(session)) return false;
+            return performSeamlessCredentialRefreshRef.current(oldCleanup, connId);
+          },
         );
+        if (!isSessionAlive(session)) {
+          conn.cleanup();
+          return;
+        }
+        webrtcConnectionRef.current = conn;
+        activeConnectionIdRef.current = conn.id;
         return;
       }
 
@@ -205,9 +506,8 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
           video.play().catch(() => {});
         });
         hls.on(Hls.Events.ERROR, (_event, data) => {
-          if (data.fatal) {
-            setError('Не удалось воспроизвести HLS-поток');
-          }
+          if (!data.fatal || !isSessionAlive(session)) return;
+          scheduleStreamRetry(session, 'Не удалось воспроизвести HLS-поток');
         });
       } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
         video.src = streamUrl;
@@ -219,15 +519,27 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
         });
       }
     } catch (err) {
-      const message = cleanErrorMessage(err);
+      if (!isSessionAlive(session)) return;
+      const message = normalizeStreamErrorMessage(err);
       if (privacyEnabled || message.includes('приват') || message.includes('не умеет')) {
         setPrivacyNotice('Камера может быть в режиме приватности. Отключите его кнопкой ниже.');
+        reportStreamError(message);
+        return;
       }
-      setError(message);
+      if (isNonRetryableStreamError(message)) {
+        reportStreamError(message);
+        return;
+      }
+      if (streamProtocol || silent) {
+        captureFreezeFrame();
+      }
+      scheduleStreamRetry(session, message);
     } finally {
-      setIsLoading(false);
+      if (isSessionAlive(session)) {
+        setIsLoading(false);
+      }
     }
-  }, [cleanupPlayer, device.id, onGetStream, privacyEnabled, captureFreezeFrame]);
+  }, [cleanupPlayer, clearPendingTimers, device.id, onGetStream, privacyEnabled, captureFreezeFrame, enterPrivacyWaitingState, reportStreamError, isSessionAlive, scheduleSessionTimer, scheduleStreamRetry, blankPiPIfVideo, streamProtocol]);
 
   const handleTogglePrivacy = useCallback(async () => {
     setIsTogglingPrivacy(true);
@@ -248,7 +560,7 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
         setPrivacyNotice('Режим приватности включён. Камера не передаёт видео.');
       }
     } catch (err) {
-      const message = cleanErrorMessage(err);
+      const message = err instanceof Error ? err.message : 'Не удалось изменить режим приватности';
       setError(message);
     } finally {
       setIsTogglingPrivacy(false);
@@ -290,6 +602,22 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
     // Silent reconnect with the new quality (no black flash, no loading spinner)
     loadStreamRef.current?.(true);
   }, []);
+
+  // Boost camera audio above the HTMLMediaElement 1.0 volume cap (WebRTC / HLS).
+  useEffect(() => {
+    if (!isOpen || !streamProtocol) return;
+    const video = videoRef.current;
+    if (!video) return;
+
+    video.muted = false;
+    video.volume = 1;
+    audioBoostRef.current = attachVideoAudioBoost(video);
+
+    return () => {
+      audioBoostRef.current?.release();
+      audioBoostRef.current = null;
+    };
+  }, [isOpen, streamProtocol]);
 
   // Hide freeze-frame overlay once the live stream resumes
   useEffect(() => {
@@ -341,22 +669,38 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
     loadStreamRef.current = loadStream;
   });
 
+  // OS notification "Повторить" → reconnect this camera
+  useEffect(() => {
+    if (!isOpen || !window.api?.onCameraStreamRetry) return;
+
+    const unsubscribe = window.api.onCameraStreamRetry(({ deviceId }) => {
+      if (deviceId !== device.id) return;
+      streamRetryCountRef.current = 0;
+      setError(null);
+      setReconnectNotice(null);
+      loadStreamRef.current?.();
+    });
+
+    return unsubscribe;
+  }, [isOpen, device.id]);
+
   // While streaming: poll every 20 s to catch physical privacy-button presses.
   // While privacy is ON (no stream): poll every 5 s waiting for it to be lifted,
   // then auto-reconnect so the user doesn't have to press "Повторить" manually.
   useEffect(() => {
     if (!isOpen || isLoading) return;
 
+    const session = sessionRef.current;
     const isWaitingForPrivacy = privacyEnabled && !streamProtocol && !error;
     const interval = isWaitingForPrivacy ? 5000 : 20000;
 
-    const poll = setInterval(async () => {
-      await refreshCameraDevice();
-      // Auto-reconnect is handled by the privacyEnabled-change effect below
+    const poll = setInterval(() => {
+      if (!isSessionAlive(session)) return;
+      void refreshCameraDevice({ retry: false });
     }, interval);
 
     return () => clearInterval(poll);
-  }, [isOpen, streamProtocol, isLoading, error, privacyEnabled, refreshCameraDevice]);
+  }, [isOpen, streamProtocol, isLoading, error, privacyEnabled, refreshCameraDevice, isSessionAlive]);
 
   // React when privacy state changes mid-session.
   useEffect(() => {
@@ -368,7 +712,7 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
       cleanupPlayer();
       setStreamProtocol(null);
       setError(null);
-      setPrivacyNotice('Режим приватности включён. Камера не передаёт видео.');
+      setPrivacyNotice(PRIVACY_ON_NOTICE);
     }
 
     if (wasEnabled && !privacyEnabled && !streamProtocol && !isLoading && isOpen) {
@@ -383,12 +727,34 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
       cleanupPlayer();
       setError(null);
       setPrivacyNotice(null);
+      setReconnectNotice(null);
       setStreamProtocol(null);
       return;
     }
 
-    void refreshCameraDevice();
-    loadStreamRef.current?.();
+    const session = sessionRef.current;
+
+    const openStream = async () => {
+      if (isCameraPrivacyModeEnabled(device)) {
+        enterPrivacyWaitingState();
+        void refreshCameraDevice({ retry: false });
+        return;
+      }
+
+      const refreshedDevice = await refreshCameraDevice({ retry: true });
+      if (!isSessionAlive(session)) {
+        return;
+      }
+
+      if (isCameraPrivacyModeEnabled(refreshedDevice)) {
+        enterPrivacyWaitingState();
+        return;
+      }
+
+      loadStreamRef.current?.();
+    };
+
+    void openStream();
 
     return () => {
       cleanupPlayer();
@@ -396,23 +762,26 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
+  // Final safety net when Dashboard unmounts the modal entirely
+  useEffect(() => () => { cleanupPlayer(); }, [cleanupPlayer]);
+
   if (!isOpen) {
     return null;
   }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
-      <div className="bg-white dark:bg-surface border border-gray-200 dark:border-border-soft rounded-2xl shadow-2xl w-full max-w-4xl overflow-hidden">
-        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-border-soft">
+      <div className="bg-white dark:bg-surface border border-gray-200 dark:border-white/10 rounded-2xl shadow-2xl w-full max-w-4xl">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-white/10 rounded-t-2xl">
           <div className="flex items-center gap-3 min-w-0">
-            <div className="p-2 rounded-full bg-[#176f91]/10 dark:bg-primary/20 text-[#176f91] dark:text-primary">
+            <div className="p-2 rounded-full bg-purple-50 dark:bg-primary/20 text-purple-600 dark:text-primary">
               <Video className="w-5 h-5" />
             </div>
             <div className="min-w-0">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-card-fg truncate">
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 truncate">
                 {cameraDevice.name}
               </h2>
-              <p className="text-xs text-gray-500 dark:text-muted">
+              <p className="text-xs text-gray-500 dark:text-slate-400">
                 {privacyEnabled
                   ? 'Режим приватности включён'
                   : streamProtocol
@@ -429,7 +798,7 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
                 className={`hidden sm:inline-flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 ${
                   privacyEnabled
                     ? 'bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-500/20'
-                    : 'bg-gray-100 dark:bg-surface text-slate-700 dark:text-card-fg hover:bg-gray-200 dark:hover:bg-surface-warm'
+                    : 'bg-gray-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-gray-200 dark:hover:bg-slate-700'
                 }`}
                 title={privacyEnabled ? 'Отключить режим приватности' : 'Включить режим приватности'}
               >
@@ -449,8 +818,8 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
                 disabled={isLoading || !streamProtocol}
                 className={`p-2 rounded-lg transition-colors disabled:opacity-50 ${
                   isPictureInPicture
-                    ? 'text-[#176f91] dark:text-primary bg-[#176f91]/10 dark:bg-primary/20'
-                    : 'text-gray-500 dark:text-muted hover:bg-gray-100 dark:hover:bg-surface'
+                    ? 'text-purple-600 dark:text-primary bg-purple-50 dark:bg-primary/20'
+                    : 'text-gray-500 dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700'
                 }`}
                 title={isPictureInPicture ? 'Закрыть окно поверх других' : 'Окно поверх других приложений'}
               >
@@ -460,7 +829,7 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
             <button
               onClick={() => videoRef.current?.requestFullscreen?.()}
               disabled={isLoading || !streamProtocol}
-              className="p-2 rounded-lg text-gray-500 dark:text-muted hover:bg-gray-100 dark:hover:bg-surface transition-colors disabled:opacity-50"
+              className="p-2 rounded-lg text-gray-500 dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors disabled:opacity-50"
               title="Полноэкранный режим"
             >
               <Maximize2 className="w-5 h-5" />
@@ -468,14 +837,14 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
             <button
               onClick={loadStream}
               disabled={isLoading || isTogglingPrivacy}
-              className="p-2 rounded-lg text-gray-500 dark:text-muted hover:bg-gray-100 dark:hover:bg-surface transition-colors disabled:opacity-50"
+              className="p-2 rounded-lg text-gray-500 dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors disabled:opacity-50"
               title="Обновить поток"
             >
               <RefreshCw className={`w-5 h-5 ${isLoading ? 'animate-spin' : ''}`} />
             </button>
             <button
               onClick={onClose}
-              className="p-2 rounded-lg text-gray-500 dark:text-muted hover:bg-gray-100 dark:hover:bg-surface transition-colors"
+              className="p-2 rounded-lg text-gray-500 dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors"
               title="Закрыть"
             >
               <X className="w-5 h-5" />
@@ -483,18 +852,24 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
           </div>
         </div>
 
-        <div className="relative bg-black aspect-video">
+        <div className="relative w-full aspect-video overflow-hidden rounded-b-2xl bg-black">
           <video
-            ref={videoRef}
-            className="w-full h-full object-contain"
-            controls
+            ref={stagingVideoRef}
+            className="hidden"
             playsInline
             muted
+            aria-hidden
+          />
+          <video
+            ref={videoRef}
+            className="block h-full w-full object-contain"
+            controls
+            playsInline
             autoPlay
           />
           <canvas
             ref={freezeCanvasRef}
-            className={`absolute inset-0 w-full h-full object-contain pointer-events-none ${showFreezeFrame ? 'z-[5]' : 'hidden'}`}
+            className={`absolute inset-0 h-full w-full object-contain pointer-events-none ${showFreezeFrame ? 'z-[5]' : 'hidden'}`}
           />
 
           {isLoading && (
@@ -523,7 +898,7 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
                       onClick={() => handleQualityChange(preset)}
                       className={`w-full px-3 py-2 text-xs text-left transition-colors ${
                         selectedQuality.label === preset.label
-                          ? 'bg-[#176f91] text-white font-semibold'
+                          ? 'bg-purple-600 text-white font-semibold'
                           : 'text-white/80 hover:bg-white/10'
                       }`}
                     >
@@ -535,7 +910,14 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
             </div>
           )}
 
-          {privacyNotice && !error && !isLoading && (
+          {reconnectNotice && !error && (
+            <div className="absolute bottom-3 left-3 right-3 flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-slate-900/90 text-white text-xs text-center">
+              <Loader2 className="w-4 h-4 shrink-0 animate-spin" />
+              <span>{reconnectNotice}</span>
+            </div>
+          )}
+
+          {privacyNotice && !error && !isLoading && !reconnectNotice && (
             <div className="absolute bottom-3 left-3 right-3 px-3 py-2 rounded-lg bg-amber-500/90 text-white text-xs text-center">
               {privacyNotice}
             </div>
@@ -565,7 +947,7 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
                 )}
                 <button
                   onClick={loadStream}
-                  className="px-4 py-2 rounded-lg bg-[#176f91] hover:bg-[#145a72] text-sm font-medium"
+                  className="px-4 py-2 rounded-lg bg-purple-600 hover:bg-purple-700 text-sm font-medium"
                 >
                   Повторить
                 </button>
@@ -574,9 +956,6 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
           )}
         </div>
 
-        <div className="px-5 py-3 text-xs text-gray-500 dark:text-muted border-t border-gray-200 dark:border-border-soft">
-          WebRTC может показывать чёрный экран в режиме приватности. Переключите приватность как в приложении «Дом с Алисой».
-        </div>
       </div>
     </div>
   );

--- a/src/components/modals/CameraStreamModal.tsx
+++ b/src/components/modals/CameraStreamModal.tsx
@@ -7,6 +7,7 @@ import { getQuasarCameraDevice } from '../../services/yandexIoT';
 import {
   hasCameraPrivacyControl,
   isCameraPrivacyModeEnabled,
+  isYandexCameraDevice,
   mergeCameraDeviceState,
   getCameraPrivacyInstance,
 } from '../../constants';
@@ -603,7 +604,7 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
     loadStreamRef.current?.(true);
   }, []);
 
-  // Boost camera audio above the HTMLMediaElement 1.0 volume cap (WebRTC / HLS).
+  // Boost Yandex camera audio above the HTMLMediaElement 1.0 volume cap (mics are often quiet).
   useEffect(() => {
     if (!isOpen || !streamProtocol) return;
     const video = videoRef.current;
@@ -611,13 +612,15 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
 
     video.muted = false;
     video.volume = 1;
-    audioBoostRef.current = attachVideoAudioBoost(video);
+    if (isYandexCameraDevice(cameraDevice)) {
+      audioBoostRef.current = attachVideoAudioBoost(video);
+    }
 
     return () => {
       audioBoostRef.current?.release();
       audioBoostRef.current = null;
     };
-  }, [isOpen, streamProtocol]);
+  }, [isOpen, streamProtocol, cameraDevice]);
 
   // Hide freeze-frame overlay once the live stream resumes
   useEffect(() => {

--- a/src/constants/deviceTypes.test.ts
+++ b/src/constants/deviceTypes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isSensorDevice, isLightDevice, isCameraDevice, isAlwaysOnDevice, isLightGroup } from './deviceTypes';
+import { isSensorDevice, isLightDevice, isCameraDevice, isYandexCameraDevice, isAlwaysOnDevice, isLightGroup } from './deviceTypes';
 
 describe('isSensorDevice', () => {
     it('should return true for devices.types.sensor.temperature', () => {
@@ -98,6 +98,26 @@ describe('isCameraDevice', () => {
         expect(isCameraDevice({
             type: 'devices.types.light',
             capabilities: [],
+            id: 'test',
+            name: 'test',
+        } as any)).toBe(false);
+    });
+});
+
+describe('isYandexCameraDevice', () => {
+    it('should return true for native Yandex camera types', () => {
+        expect(isYandexCameraDevice({
+            type: 'devices.types.camera',
+            capabilities: [],
+            id: 'test',
+            name: 'test',
+        } as any)).toBe(true);
+    });
+
+    it('should return false for partner cameras with video_stream on other types', () => {
+        expect(isYandexCameraDevice({
+            type: 'devices.types.other',
+            capabilities: [{ type: 'devices.capabilities.video_stream' }],
             id: 'test',
             name: 'test',
         } as any)).toBe(false);

--- a/src/constants/deviceTypes.ts
+++ b/src/constants/deviceTypes.ts
@@ -24,6 +24,11 @@ export const isCameraDevice = (device: YandexDevice): boolean => {
         || device.capabilities.some((cap) => cap.type === 'devices.capabilities.video_stream');
 };
 
+/** Native Yandex cameras use devices.types.camera; partner cameras expose video_stream on other types. */
+export const isYandexCameraDevice = (device: YandexDevice): boolean => {
+    return device.type.startsWith('devices.types.camera');
+};
+
 export const isAlwaysOnDevice = (device: YandexDevice): boolean => {
     const t = device.type.toLowerCase();
     return t.includes('smart_speaker') || t.includes('hub') || t.includes('other');

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { fetchUserInfo } from '../services/yandexIoT';
 import { AppState, YandexUserInfoResponse } from '../types/index';
 import { stableSortData } from '../utils/dataUtils';
@@ -7,6 +7,7 @@ import { cleanErrorMessage } from '../utils/errors';
 const yandexApi = window.api;
 
 interface RetryInfo {
+    action: string;
     attempt: number;
     maxAttempts: number;
     message: string;
@@ -33,15 +34,22 @@ export function useAuth(): UseAuthReturn {
     const [errorMsg, setErrorMsg] = useState<string | undefined>(undefined);
     const [retryInfo, setRetryInfo] = useState<RetryInfo | null>(null);
     const [userData, setUserData] = useState<YandexUserInfoResponse | null>(null);
+    const appStateRef = useRef(appState);
+
+    useEffect(() => {
+        appStateRef.current = appState;
+    }, [appState]);
 
     const loadData = useCallback(async (apiToken: string) => {
         setAppState(AppState.LOADING);
         setErrorMsg(undefined);
+        setRetryInfo(null);
         try {
             const data = await fetchUserInfo(apiToken);
             const sortedData = stableSortData(data);
             setUserData(sortedData);
             setAppState(AppState.DASHBOARD);
+            setRetryInfo(null);
             // promptXTokenIfNeeded будет вызываться из useYandexData
         } catch (err: unknown) {
             setErrorMsg(cleanErrorMessage(err));
@@ -80,6 +88,12 @@ export function useAuth(): UseAuthReturn {
     useEffect(() => {
         if (!window.api?.onRetryAttempt) return;
         const unsubscribe = window.api.onRetryAttempt((data: RetryInfo) => {
+            if (appStateRef.current !== AppState.LOADING) {
+                return;
+            }
+            if (data.action !== 'fetchUserInfo') {
+                return;
+            }
             setRetryInfo(data);
         });
         return () => {

--- a/src/hooks/useYandexData.ts
+++ b/src/hooks/useYandexData.ts
@@ -34,7 +34,7 @@ export function useYandexData(
             setIsRefreshing(true);
         }
         try {
-            const data = await fetchUserInfo(apiToken);
+            const data = await fetchUserInfo(apiToken, { retry: !silent });
             const sortedData = stableSortData(data);
             const hasChanges = hasDeviceStateChanges(userDataRef.current, sortedData);
             setUserData(sortedData);

--- a/src/services/yandexGoloomWebRtc.ts
+++ b/src/services/yandexGoloomWebRtc.ts
@@ -6,6 +6,8 @@ const VIDEO_TIMEOUT_MS = 30000;
 const KEEPALIVE_INTERVAL_MS = 25000;
 /** Refresh credentials this many ms before JWT expiry */
 const JWT_REFRESH_LEAD_MS = 60000;
+/** Retry staging connect when server reports too many peers (overlap with old session) */
+const TOO_MANY_PEERS_RETRY_MS = 4000;
 /** Fast-path may reuse cached room JWT only if it remains valid at least this long */
 export const JWT_FAST_REUSE_MIN_TTL_MS = 90_000;
 
@@ -146,6 +148,8 @@ const waitForVideoFrame = (video: HTMLVideoElement) => new Promise<void>((resolv
     checkReady();
 });
 
+export { waitForVideoFrame, TOO_MANY_PEERS_RETRY_MS };
+
 const sendAck = (ws: WebSocket, uid: string) => {
     ws.send(JSON.stringify({ uid, ack: { status: { code: 'OK' } } }));
 };
@@ -242,6 +246,8 @@ const handleSignalingMessage = async (
 };
 
 export interface GoloomConnection {
+    /** Unique id — only the active connection should handle JWT refresh. */
+    id: string;
     /** Full cleanup — stops stream and clears the video element. */
     cleanup: () => void;
     /** Soft cleanup — stops the WebSocket/PeerConnection but keeps the last video frame visible. */
@@ -254,8 +260,9 @@ export const connectYandexGoloomWebRtc = async (
     video: HTMLVideoElement,
     onDisconnect?: () => void,
     initialQuality: { width: number; height: number } = { width: 2560, height: 1440 },
-    onCredentialRefresh?: () => void,
+    onCredentialRefresh?: (cleanupOld: () => void, connectionId: string) => boolean | Promise<boolean>,
 ): Promise<GoloomConnection> => {
+    const connectionId = crypto.randomUUID();
     const pendingCandidates: RTCIceCandidateInit[] = [];
     const state = { remoteDescSet: false };
     let closed = false;
@@ -273,12 +280,14 @@ export const connectYandexGoloomWebRtc = async (
     // Timers cleared on cleanup
     let keepaliveIntervalId: ReturnType<typeof setInterval> | null = null;
     let jwtRefreshTimerId: ReturnType<typeof setTimeout> | null = null;
+    let upgradeTimerId: ReturnType<typeof setTimeout> | null = null;
 
     const doCleanup = (ws: WebSocket, pc: RTCPeerConnection, unexpected = false, keepVideo = false) => {
         if (closed) return;
         closed = true;
         if (keepaliveIntervalId !== null) { window.clearInterval(keepaliveIntervalId); keepaliveIntervalId = null; }
         if (jwtRefreshTimerId !== null) { window.clearTimeout(jwtRefreshTimerId); jwtRefreshTimerId = null; }
+        if (upgradeTimerId !== null) { window.clearTimeout(upgradeTimerId); upgradeTimerId = null; }
         log('Cleanup', keepVideo ? '(keeping video frame)' : '');
         pc.close();
         if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
@@ -286,6 +295,32 @@ export const connectYandexGoloomWebRtc = async (
         }
         if (!keepVideo) video.srcObject = null;
         if (unexpected) onDisconnect?.();
+    };
+
+    /** Read frame width via track settings or inbound-rtp stats — no extra <video> elements. */
+    const probeTrackFrameWidth = async (track: MediaStreamTrack, rtpPc: RTCPeerConnection): Promise<number> => {
+        if (closed) return 0;
+
+        const settings = track.getSettings?.();
+        if (settings?.width && settings.width > 0) {
+            return settings.width;
+        }
+
+        const receiver = rtpPc.getReceivers().find(r => r.track?.id === track.id);
+        if (!receiver) return 0;
+
+        for (let attempt = 0; attempt < 10; attempt++) {
+            if (closed) return 0;
+            const stats = await receiver.getStats();
+            for (const report of stats.values()) {
+                if (report.type === 'inbound-rtp' && report.kind === 'video') {
+                    const w = (report as RTCInboundRtpStreamStats).frameWidth;
+                    if (w && w > 0) return w;
+                }
+            }
+            await new Promise(r => window.setTimeout(r, 200));
+        }
+        return 0;
     };
 
     log('Connecting to', room.serviceUrl);
@@ -340,7 +375,8 @@ export const connectYandexGoloomWebRtc = async (
 
         if (serverError) {
             logErr('serverHello rejected:', serverError);
-            doCleanup(ws, pc);
+            closed = true;
+            ws.close();
             const isTooManyPeers = /too.?many.?peer/i.test(serverError);
             throw new Error(
                 isTooManyPeers
@@ -362,6 +398,7 @@ export const connectYandexGoloomWebRtc = async (
     log('RTCPeerConnection created');
 
     pc.ontrack = (event) => {
+        if (closed) return;
         const t = event.track;
         const txMid = event.transceiver?.mid ?? '';
         log('ontrack kind:', t.kind, '| mid:', txMid || '(empty)', '| id:', t.id.slice(0, 8), '| enabled:', t.enabled, '| readyState:', t.readyState, '| streams:', event.streams.length);
@@ -369,22 +406,7 @@ export const connectYandexGoloomWebRtc = async (
             const stream = event.streams[0] ?? new MediaStream([t]);
             videoStreams.set(txMid, stream);
             log('Stored video stream for mid:', txMid || '(empty)', '| stream id:', stream.id.slice(0, 8));
-            // Log sub-stream resolution when available
-            if (txMid === 'video_AB') {
-                const tmpVid = document.createElement('video');
-                tmpVid.muted = true;
-                tmpVid.srcObject = stream;
-                const logAndCleanup = () => {
-                    log('video_AB resolution:', tmpVid.videoWidth, 'x', tmpVid.videoHeight);
-                    tmpVid.srcObject = null;
-                };
-                tmpVid.addEventListener('loadedmetadata', logAndCleanup, { once: true });
-                tmpVid.addEventListener('resize', logAndCleanup, { once: true });
-                tmpVid.load();
-            }
-            // Always set srcObject from the first arriving video track so stale
-            // tracks from a previous soft-cleanup connection don't remain visible.
-            if (videoStreams.size === 1) {
+            if (videoStreams.size === 1 && !closed) {
                 log('Setting initial srcObject from first video track');
                 video.srcObject = stream;
                 video.muted = false;
@@ -394,8 +416,6 @@ export const connectYandexGoloomWebRtc = async (
             log('Stored audio track, total:', audioTracks.length);
         }
         t.addEventListener('ended', () => logErr('track ended, kind:', t.kind, '| mid:', txMid));
-        t.addEventListener('mute', () => log('track muted, kind:', t.kind, '| mid:', txMid));
-        t.addEventListener('unmute', () => log('track unmuted, kind:', t.kind, '| mid:', txMid));
     };
 
     pc.onicecandidate = (event) => {
@@ -487,44 +507,38 @@ export const connectYandexGoloomWebRtc = async (
                     log('Added audio track to combined stream, id:', at.id.slice(0, 8));
                 }
                 log('Switching srcObject to combined stream: video+', audioTracks.length, 'audio track(s)');
-                video.srcObject = combined;
-                video.muted = false;
+                if (!closed) {
+                    video.srcObject = combined;
+                    video.muted = false;
+                }
             }
         }
 
-        // Probe all available video streams and pick the highest-resolution one.
-        // The server may assign a lower-resolution stream as the "primary" slot.
-        const probeVideoWidth = (stream: MediaStream): Promise<number> =>
-            new Promise(resolve => {
-                const tmp = document.createElement('video');
-                tmp.muted = true;
-                tmp.srcObject = stream;
-                const done = () => { resolve(tmp.videoWidth); tmp.srcObject = null; };
-                tmp.addEventListener('loadedmetadata', done, { once: true });
-                tmp.addEventListener('resize', done, { once: true });
-                tmp.load();
-                window.setTimeout(() => { resolve(0); tmp.srcObject = null; }, 3000);
-            });
-
-        // Run probing in background after play; switches srcObject if a better stream exists
+        // Probe available streams and pick the highest-resolution track (via getStats, not temp <video>).
         const upgradeToHighestQuality = async () => {
             if (closed) return;
             let bestWidth = video.videoWidth;
             let bestTrack: MediaStreamTrack | undefined;
+            let bestMid = '';
             for (const [mid, stream] of videoStreams) {
+                if (closed) return;
                 const track = stream.getVideoTracks()[0];
                 if (!track || track.readyState !== 'live') continue;
-                const w = await probeVideoWidth(stream);
+                const w = await probeTrackFrameWidth(track, pc);
+                if (closed) return;
                 log('Probed mid:', mid, '→', w, 'x (current best:', bestWidth, ')');
-                if (w > bestWidth) { bestWidth = w; bestTrack = track; }
+                if (w > bestWidth) {
+                    bestWidth = w;
+                    bestTrack = track;
+                    bestMid = mid;
+                }
             }
-            if (bestTrack && !closed) {
-                log('Upgrading to higher quality track, width:', bestWidth);
-                const combined = new MediaStream([bestTrack, ...audioTracks]);
-                video.srcObject = combined;
-                video.muted = false;
-                try { await video.play(); } catch { /* ignore */ }
-            }
+            if (!bestTrack || closed) return;
+            log('Upgrading to higher quality track, mid:', bestMid, 'width:', bestWidth);
+            const combined = new MediaStream([bestTrack, ...audioTracks]);
+            video.srcObject = combined;
+            video.muted = false;
+            try { await video.play(); } catch { /* ignore */ }
         };
 
         log('video state BEFORE play:', video.srcObject ? `stream(${(video.srcObject as MediaStream).getTracks().map(t => `${t.kind}:${t.readyState}:enabled=${t.enabled}`).join(',')})` : 'null', '| readyState:', video.readyState, '| videoWidth:', video.videoWidth);
@@ -543,7 +557,7 @@ export const connectYandexGoloomWebRtc = async (
         // Auto-upgrade only when high quality was requested (not when user intentionally chose low)
         const isHighQualityRequest = initialQuality.width === 0 || initialQuality.width >= 1920;
         if (isHighQualityRequest) {
-            window.setTimeout(() => { void upgradeToHighestQuality(); }, 1000);
+            upgradeTimerId = window.setTimeout(() => { void upgradeToHighestQuality(); }, 1000);
         }
 
         // ── Keepalive ────────────────────────────────────────────────────────────
@@ -564,14 +578,27 @@ export const connectYandexGoloomWebRtc = async (
             log(`JWT exp in ${Math.round(msLeft / 1000)} s — proactive refresh scheduled in ${Math.round(refreshIn / 1000)} s`);
             const triggerCredentialRefresh = () => {
                 if (closed) return;
-                log('JWT expiring soon — triggering credential refresh reconnect');
-                intentionalClose = true;
+                log('JWT expiring soon — triggering seamless credential refresh');
+                const cleanupOld = () => doCleanup(ws, pc, false, true);
                 if (onCredentialRefresh) {
-                    onCredentialRefresh();
+                    void Promise.resolve(onCredentialRefresh(cleanupOld, connectionId))
+                        .then((accepted) => {
+                            if (closed) return;
+                            if (accepted === false) return;
+                            intentionalClose = true;
+                        })
+                        .catch((err) => {
+                            logErr('credential refresh failed:', err);
+                            if (!closed) {
+                                cleanupOld();
+                                onDisconnect?.();
+                            }
+                        });
                 } else {
+                    intentionalClose = true;
+                    cleanupOld();
                     onDisconnect?.();
                 }
-                doCleanup(ws, pc, false, true);
             };
             if (refreshIn > 5000) {
                 jwtRefreshTimerId = window.setTimeout(triggerCredentialRefresh, refreshIn);
@@ -602,6 +629,7 @@ export const connectYandexGoloomWebRtc = async (
         };
 
         return {
+            id: connectionId,
             cleanup: () => doCleanup(ws, pc),
             cleanupSoft: () => doCleanup(ws, pc, false, true),
             setQuality,

--- a/src/services/yandexIoT.ts
+++ b/src/services/yandexIoT.ts
@@ -2,9 +2,12 @@ import { YandexUserInfoResponse, YandexDevice, YandexModeAction, CameraStreamRes
 
 const yandexApi = window.api;
 
-export const fetchUserInfo = async (token: string): Promise<YandexUserInfoResponse> => {
+export const fetchUserInfo = async (
+    token: string,
+    options?: { retry?: boolean },
+): Promise<YandexUserInfoResponse> => {
     try {
-        const userInfo = await yandexApi.fetchUserInfo(token) as YandexUserInfoResponse;
+        const userInfo = await yandexApi.fetchUserInfo(token, options) as YandexUserInfoResponse;
 
         const knownDeviceIds = new Set(userInfo.devices.map(d => d.id));
         const roomDeviceIds = new Set(userInfo.rooms.flatMap(r => r.devices));
@@ -108,9 +111,12 @@ export const setCameraPrivacyMode = async (
     }
 };
 
-export const getQuasarCameraDevice = async (deviceId: string): Promise<YandexDevice> => {
+export const getQuasarCameraDevice = async (
+    deviceId: string,
+    options?: { retry?: boolean },
+): Promise<YandexDevice> => {
     try {
-        return await yandexApi.getQuasarCameraDevice(deviceId);
+        return await yandexApi.getQuasarCameraDevice(deviceId, options);
     } catch (error) {
         console.error('Ошибка при получении камеры из Quasar:', error);
         throw error;

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -1,8 +1,12 @@
 // electron-api.d.ts
 import { YandexUserInfoResponse, YandexDevice, TrayMenuItem, YandexModeAction, CameraStreamResult } from './index'; 
 
+export interface YandexApiRequestOptions {
+    retry?: boolean;
+}
+
 export interface IYandexApi {
-    fetchUserInfo: (token: string) => Promise<YandexUserInfoResponse>;
+    fetchUserInfo: (token: string, options?: YandexApiRequestOptions) => Promise<YandexUserInfoResponse>;
     fetchDevice: (token: string, deviceId: string) => Promise<YandexDevice>; 
     executeScenario: (token: string, scenarioId: string) => Promise<void>;
     toggleDevice: (token: string, deviceId: string, newState: boolean) => Promise<void>;
@@ -10,7 +14,7 @@ export interface IYandexApi {
     setDeviceMode: (token: string, deviceId: string, modeActions: YandexModeAction[], turnOn?: boolean) => Promise<void>;
     getCameraStream: (deviceId: string) => Promise<CameraStreamResult>;
     setCameraPrivacyMode: (deviceId: string, privacyEnabled: boolean, toggleInstance?: string) => Promise<void>;
-    getQuasarCameraDevice: (deviceId: string) => Promise<YandexDevice>;
+    getQuasarCameraDevice: (deviceId: string, options?: YandexApiRequestOptions) => Promise<YandexDevice>;
 	  getSecureToken: () => Promise<string | null>;
     setSecureToken: (token: string) => Promise<void>;
     deleteSecureToken: () => Promise<void>;
@@ -31,7 +35,14 @@ export interface IYandexApi {
     onTrayCommand: (callback: (command: string, id: string, currentState?: boolean) => void) => void;
     removeTrayCommandListener: () => void;
     
-    onRetryAttempt: (callback: (data: {attempt: number, maxAttempts: number, message: string}) => void) => () => void;
+    onRetryAttempt: (callback: (data: {action: string, attempt: number, maxAttempts: number, message: string}) => void) => () => void;
+
+    showCameraStreamErrorNotification: (payload: {
+        deviceId: string;
+        deviceName: string;
+        message: string;
+    }) => Promise<boolean>;
+    onCameraStreamRetry: (callback: (data: { deviceId: string }) => void) => () => void;
 }
 
 declare global {

--- a/src/utils/videoAudioBoost.ts
+++ b/src/utils/videoAudioBoost.ts
@@ -1,0 +1,51 @@
+/** Default playback gain (~400%) — camera mics are often very quiet. */
+export const CAMERA_AUDIO_GAIN = 4.0;
+
+export interface VideoAudioBoost {
+  setGain: (value: number) => void;
+  release: () => void;
+}
+
+const attached = new WeakMap<HTMLVideoElement, VideoAudioBoost>();
+
+/**
+ * Route <video> audio through a GainNode so volume can exceed HTMLMediaElement's 1.0 cap.
+ * Safe to call repeatedly on the same element — createMediaElementSource runs once.
+ */
+export const attachVideoAudioBoost = (
+  video: HTMLVideoElement,
+  initialGain = CAMERA_AUDIO_GAIN,
+): VideoAudioBoost => {
+  const existing = attached.get(video);
+  if (existing) {
+    existing.setGain(initialGain);
+    return existing;
+  }
+
+  const ctx = new AudioContext();
+  const source = ctx.createMediaElementSource(video);
+  const gainNode = ctx.createGain();
+  gainNode.gain.value = initialGain;
+  source.connect(gainNode);
+  gainNode.connect(ctx.destination);
+
+  const resume = () => { void ctx.resume(); };
+  video.addEventListener('play', resume);
+  void ctx.resume();
+
+  const boost: VideoAudioBoost = {
+    setGain: (value) => { gainNode.gain.value = value; },
+    release: () => {
+      video.removeEventListener('play', resume);
+      attached.delete(video);
+      try {
+        source.disconnect();
+        gainNode.disconnect();
+      } catch { /* ignore */ }
+      void ctx.close();
+    },
+  };
+
+  attached.set(video, boost);
+  return boost;
+};


### PR DESCRIPTION
Summary
Порт доработок стабильности камер v1.8.3–v1.8.6 на актуальную ветку main (v2.0.2).

Базовая поддержка камер уже была влита в #22. Этот PR добавляет последующие исправления, которые не попали в upstream, с адаптацией под архитектуру v2.0 (хуки useAuth / useYandexData, без отката редизайна).

Что входит
v1.8.3 — бесшовный refresh потока

Обновление JWT без мерцания кадра (hot-swap соединения)
Исправление счётчика retry и ложного error overlay
Пропуск подключения к стриму при известном режиме приватности
Исправление race при upgrade качества после cleanup
v1.8.4 — утечка соединений

Корректное завершение WebRTC/WebSocket при закрытии модалки камеры
Session-based lifecycle: async-операции не продолжаются после unmount
v1.8.5 — надёжность и аудио

single-flight для Quasar API (не сбрасывает retry-счётчик при параллельных запросах)
Опция { retry: false } для silent refresh дашборда
Web Audio boost (4×) только для Яндекс-камер (devices.types.camera*)
Сторонние камеры с video_stream на других типах устройств — без boost
v1.8.6 — auto-retry и UX

Автоматический retry потока при transient-ошибках (до 10 попыток)
PiP: чёрный экран вместо закрытия окна при silent reconnect
OS-уведомления с кнопкой «Повторить» при ошибке потока
Затронутые области
CameraStreamModal.tsx — основная логика стабильности
yandexGoloomWebRtc.ts — seamless JWT refresh, connection id, quality probe
videoAudioBoost.ts — новый утилитарный модуль (Yandex-only)
electron/main.js, preload.cjs, yandex-api.js — IPC, notifications, single-flight
useAuth.ts, useYandexData.ts — фильтрация retry только для fetchUserInfo при загрузке
