### PR TITLE
fix(camera): падение UI при стриме камеры и восстановление звука

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -251,11 +251,31 @@ function createWindow () {
      if (isDev) {
         mainWindow.setTitle('[DEV] Yandex Smart Home Control');
         mainWindow.loadURL(DEV_VITE_URL);
+        mainWindow.webContents.openDevTools({ mode: 'detach' });
         mainWindow.webContents.on('console-message', (_event, level, message) => {
-            if (message.includes('[Goloom]') || message.includes('[Camera]')) {
+            const interesting =
+                message.includes('[Goloom]')
+                || message.includes('[Camera]')
+                || message.includes('[Debug:')
+                || message.includes('InvalidStateError')
+                || message.includes('MediaElementSource')
+                || message.includes('createMediaElementSource');
+            if (interesting) {
                 const prefix = level === 3 ? '[Renderer:ERR]' : '[Renderer]';
                 console.log(prefix, message);
             }
+        });
+        mainWindow.webContents.on('render-process-gone', (_event, details) => {
+            console.error('[Electron] render-process-gone', details);
+        });
+        mainWindow.webContents.on('unresponsive', () => {
+            console.error('[Electron] webContents unresponsive');
+        });
+        mainWindow.webContents.on('did-fail-load', (_event, code, desc, url) => {
+            console.error('[Electron] did-fail-load', { code, desc, url });
+        });
+        mainWindow.webContents.on('did-finish-load', () => {
+            console.log('[Electron] did-finish-load');
         });
      } else {
         mainWindow.loadFile(path.join(__dirname, '..', 'dist', 'index.html'));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import DashboardContext from './contexts/DashboardContext';
 import { useNotification, useAuth, useFavorites, useNavigation, useUpdateNotification,
          useCameraAuth, useYandexData, useDeviceActions, useHousehold, useAutostart } from './hooks';
 import packageJson from '../package.json';
+import { debugLog, debugWarn, refreshDebugFlags } from './utils/debugLog';
 
 const yandexApi = window.api;
 
@@ -44,9 +45,23 @@ function App() {
     // 5. Зависит от showNotification
     const { isAutostartEnabled, handleToggleAutostart } = useAutostart(showNotification);
 
+    // Track AppState transitions — blank UI with only CSS background often means LOADING
+    // (bg-transparent) or AUTH after an unexpected re-init / session wipe.
+    const prevAppStateRef = React.useRef(appState);
+    useEffect(() => {
+        if (prevAppStateRef.current !== appState) {
+            debugLog('app', 'appState', prevAppStateRef.current, '→', appState, {
+                hasToken: Boolean(token),
+                hasUserData: Boolean(userData),
+            });
+            prevAppStateRef.current = appState;
+        }
+    }, [appState, token, userData]);
+
     // --- Колбэки для связывания хуков ---
 
     const handleLoadData = useCallback(async (apiToken: string) => {
+        debugLog('app', 'handleLoadData start');
         setAppState(AppState.LOADING);
         setErrorMsg(undefined);
         try {
@@ -55,7 +70,9 @@ function App() {
             setUserData(sortedData);
             setAppState(AppState.DASHBOARD);
             await promptXTokenIfNeeded(sortedData);
+            debugLog('app', 'handleLoadData ok', { devices: sortedData.devices?.length });
         } catch (err) {
+            debugWarn('app', 'handleLoadData failed', err);
             setErrorMsg(cleanErrorMessage(err));
             setAppState(AppState.AUTH);
             if (err instanceof Error && (err.message.includes('401') || err.message.includes('403'))) {
@@ -65,6 +82,11 @@ function App() {
         }
     }, [setUserData, setAppState, setErrorMsg, setToken, promptXTokenIfNeeded]);
 
+    const handleLoadDataRef = React.useRef(handleLoadData);
+    useEffect(() => {
+        handleLoadDataRef.current = handleLoadData;
+    }, [handleLoadData]);
+
     const handleTokenSubmit = useCallback(async (newToken: string) => {
         setToken(newToken);
         await yandexApi.setSecureToken(newToken);
@@ -72,6 +94,7 @@ function App() {
     }, [setToken, handleLoadData]);
 
     const handleLogout = useCallback(async () => {
+        debugLog('app', 'logout');
         await yandexApi.deleteSecureToken();
         setToken(null);
         setUserData(null);
@@ -80,6 +103,7 @@ function App() {
     }, [setToken, setUserData, setErrorMsg, setAppState]);
 
     const handleCancelRetry = useCallback(async () => {
+        debugLog('app', 'cancel retry');
         await yandexApi.deleteSecureToken();
         setToken(null);
         setUserData(null);
@@ -88,20 +112,25 @@ function App() {
     }, [setToken, setUserData, setErrorMsg, setAppState]);
 
     // --- 1. Init-эффект (проверка токена при запуске) ---
+    // Intentionally empty deps: must run once. Re-running on handleLoadData identity
+    // would set AppState.LOADING and wipe the dashboard (transparent bg = "only background").
     useEffect(() => {
+        refreshDebugFlags();
+        debugLog('app', 'init: checkToken');
         const checkToken = async () => {
             setAppState(AppState.LOADING);
             const storedToken = await yandexApi.getSecureToken();
             if (storedToken) {
                 setToken(storedToken);
-                await handleLoadData(storedToken);
+                await handleLoadDataRef.current(storedToken);
             } else {
                 setErrorMsg(undefined);
                 setAppState(AppState.AUTH);
             }
         };
-        checkToken();
-    }, [handleLoadData]);
+        void checkToken();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // --- 2. Вспомогательная функция для подготовки данных для трея ---
     const getTrayMenuItems = useCallback((

--- a/src/components/cards/DeviceCard.tsx
+++ b/src/components/cards/DeviceCard.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
 import { YandexDevice } from '../../types/index';
-import { getIconForDevice, localizeUnit, isCameraDevice, isAlwaysOnDevice, formatFloatValue } from '../../constants';
+import { getIconForDevice, localizeUnit, isCameraDevice, isAlwaysOnDevice, formatFloatValue, isCameraPrivacyModeEnabled } from '../../constants';
 import { Loader2, Star, Settings, Eye, EyeOff, Video, Mic, MicOff, Thermometer, Droplets } from 'lucide-react';
 import { SensorDisplayConfig } from '../modals/SensorSettingsModal';
+import { debugLog } from '../../utils/debugLog';
+
+const loggedCameraCardIds = new Set<string>();
 
 export interface DeviceCardProps {
   device: YandexDevice;
@@ -51,11 +54,29 @@ export const DeviceCard: React.FC<DeviceCardProps> = ({ device, onToggle, isFavo
     return type === 'devices.properties.float' && instance === 'humidity';
   }) as any | undefined;
 
+  // Mic badge only for explicit microphone / hardware-mute properties.
+  // Never treat `camera_sw_mute` as a mic — that capability is the privacy shutter.
+  const hwMuteProperty = (device.properties ?? []).find(prop => {
+    const anyProp = prop as any;
+    const instance: string | undefined = anyProp?.parameters?.instance ?? anyProp?.state?.instance;
+    return instance === 'camera_hw_mute';
+  }) as any | undefined;
+
   const microphoneProperty = (device.properties ?? []).find(prop => {
     const anyProp = prop as any;
     const instance: string | undefined = anyProp?.parameters?.instance ?? anyProp?.state?.instance;
-    return !!instance && (instance.includes('microphone') || instance.includes('mic') || instance.includes('mute'));
+    if (!instance) return false;
+    const id = instance.toLowerCase();
+    if (id === 'camera_hw_mute' || id === 'camera_sw_mute' || id.includes('camera_sw')) return false;
+    return id === 'microphone' || id === 'mic' || id.endsWith('_microphone') || id.endsWith('_mic')
+      || id.includes('microphone');
   }) as any | undefined;
+
+  // Privacy shutter lives on capabilities (camera_sw_mute), not the mic badge.
+  const privacyOn = isCamera && isCameraPrivacyModeEnabled(device);
+  const hwMuteValue = String(hwMuteProperty?.state?.value ?? '');
+  const isHwMuteOn = hwMuteValue.includes('enabled') && !hwMuteValue.includes('disabled');
+
 
   const temperatureValue: number | null = temperatureProperty?.state?.value ?? null;
   const temperatureUnit = temperatureProperty?.parameters?.unit
@@ -73,16 +94,41 @@ export const DeviceCard: React.FC<DeviceCardProps> = ({ device, onToggle, isFavo
 
   const isSensor = !isToggleable && !!sensorProperty;
 
-  const isMicrophoneSensor = isCamera && (!!microphoneProperty || isSensor);
-  const micState: string | undefined = microphoneProperty?.state?.value ?? sensorProperty?.state?.value;
-  const micInstance: string | undefined = (microphoneProperty || sensorProperty)?.parameters?.instance ?? (microphoneProperty || sensorProperty)?.state?.instance;
-  const isMuteType = !!micInstance && micInstance.includes('mute');
-  // Для mute-типов: mute enabled = микрофон ВЫКЛ, mute disabled = микрофон ВКЛ
-  // Для остальных: 'on'/'true' = микрофон ВКЛ
+  const showMicStatus = isCamera && (!!microphoneProperty || !!hwMuteProperty);
+  const micState: string | undefined = microphoneProperty?.state?.value;
+  const micInstance: string | undefined = microphoneProperty?.parameters?.instance ?? microphoneProperty?.state?.instance;
   const micStateStr = String(micState ?? '');
-  const isMicOn = isMuteType
-    ? micStateStr.includes('disabled') || micStateStr === 'off' || micStateStr === 'false'
-    : micStateStr === 'on' || micStateStr === 'true';
+  const isMicOn = hwMuteProperty
+    ? !isHwMuteOn
+    : micStateStr === 'on' || micStateStr === 'true' || micStateStr.includes('unmuted');
+  const micTitle = hwMuteProperty
+    ? (isHwMuteOn
+      ? 'Аппаратный микрофон выключен (кнопка на камере / настройки в приложении Дом)'
+      : 'Аппаратный микрофон включен')
+    : (isMicOn ? 'Микрофон включен' : 'Микрофон выключен');
+
+  if (isCamera && !loggedCameraCardIds.has(device.id)) {
+    loggedCameraCardIds.add(device.id);
+    debugLog('camera', 'device card status', {
+      id: device.id,
+      name: device.name,
+      propertyInstances: (device.properties ?? []).map((p: any) => ({
+        instance: p?.parameters?.instance ?? p?.state?.instance,
+        value: p?.state?.value,
+      })),
+      capabilityInstances: (device.capabilities ?? []).map((c: any) => ({
+        type: c?.type,
+        instance: c?.parameters?.instance ?? c?.state?.instance,
+        value: c?.state?.value,
+      })),
+      showMicStatus,
+      micInstance,
+      micState,
+      hwMute: hwMuteValue || null,
+      isHwMuteOn,
+      privacyOn,
+    });
+  }
 
   const sensorInstance: string | undefined = sensorProperty?.parameters?.instance ?? sensorProperty?.state?.instance;
   const rawSensorValue: unknown = sensorProperty?.state?.value;
@@ -139,10 +185,10 @@ export const DeviceCard: React.FC<DeviceCardProps> = ({ device, onToggle, isFavo
           <div className={`device-icon ${(isOn && isToggleable) || isCamera || isAlwaysOn ? 'is-on' : ''}`}>
             {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : React.cloneElement(icon as React.ReactElement<{ className?: string }>, { className: 'w-4 h-4' })}
           </div>
-          {isMicrophoneSensor && (
+          {showMicStatus && (
             <span
               className="flex-shrink-0"
-              title={isMicOn ? 'Микрофон включен' : 'Микрофон выключен'}
+              title={micTitle}
             >
               {isMicOn
                 ? <Mic className="w-3.5 h-3.5 text-green-400 dark:text-green-300" />
@@ -203,7 +249,7 @@ export const DeviceCard: React.FC<DeviceCardProps> = ({ device, onToggle, isFavo
         )}
       </div>
 
-      {isSensor && formattedSensorValue && !isMicrophoneSensor && (
+      {isSensor && formattedSensorValue && !showMicStatus && (
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', marginTop: 'auto' }}>
           <span className="device-sensor-value">{formattedSensorValue}</span>
         </div>

--- a/src/components/modals/CameraStreamModal.tsx
+++ b/src/components/modals/CameraStreamModal.tsx
@@ -12,6 +12,7 @@ import {
   getCameraPrivacyInstance,
 } from '../../constants';
 import { attachVideoAudioBoost, VideoAudioBoost } from '../../utils/videoAudioBoost';
+import { debugLog, debugWarn } from '../../utils/debugLog';
 import { X, RefreshCw, Loader2, Video, AlertCircle, Eye, EyeOff, Maximize2, Settings2, PictureInPicture2 } from 'lucide-react';
 
 const QUALITY_PRESETS = [
@@ -605,6 +606,9 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
   }, []);
 
   // Boost Yandex camera audio above the HTMLMediaElement 1.0 volume cap (mics are often quiet).
+  // Do NOT depend on cameraDevice — privacy polls refresh it every ~20s and would re-run
+  // this effect; tearing down MediaElementSource then re-attaching throws InvalidStateError
+  // and can unmount the entire React tree (blank app, only CSS background left).
   useEffect(() => {
     if (!isOpen || !streamProtocol) return;
     const video = videoRef.current;
@@ -612,15 +616,21 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
 
     video.muted = false;
     video.volume = 1;
-    if (isYandexCameraDevice(cameraDevice)) {
-      audioBoostRef.current = attachVideoAudioBoost(video);
+    if (isYandexCameraDevice(cameraDeviceRef.current)) {
+      debugLog('camera', 'attachVideoAudioBoost', { streamProtocol, videoWidth: video.videoWidth });
+      try {
+        audioBoostRef.current = attachVideoAudioBoost(video);
+      } catch (err) {
+        debugWarn('camera', 'attachVideoAudioBoost failed', err);
+      }
     }
 
     return () => {
+      debugLog('camera', 'releaseVideoAudioBoost');
       audioBoostRef.current?.release();
       audioBoostRef.current = null;
     };
-  }, [isOpen, streamProtocol, cameraDevice]);
+  }, [isOpen, streamProtocol]);
 
   // Hide freeze-frame overlay once the live stream resumes
   useEffect(() => {
@@ -726,6 +736,7 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
   }, [privacyEnabled, streamProtocol, isLoading, isOpen, cleanupPlayer]);
 
   useEffect(() => {
+    debugLog('camera', 'modal isOpen effect', { isOpen, deviceId: device.id, session: sessionRef.current });
     if (!isOpen) {
       cleanupPlayer();
       setError(null);
@@ -760,13 +771,28 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
     void openStream();
 
     return () => {
+      debugLog('camera', 'modal isOpen cleanup', { deviceId: device.id });
       cleanupPlayer();
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
   // Final safety net when Dashboard unmounts the modal entirely
-  useEffect(() => () => { cleanupPlayer(); }, [cleanupPlayer]);
+  useEffect(() => () => {
+    debugLog('camera', 'modal unmount cleanupPlayer');
+    cleanupPlayer();
+  }, [cleanupPlayer]);
+
+  useEffect(() => {
+    debugLog('camera', 'ui state', {
+      isOpen,
+      streamProtocol,
+      isLoading,
+      privacyEnabled,
+      hasError: Boolean(error),
+      session: sessionRef.current,
+    });
+  }, [isOpen, streamProtocol, isLoading, privacyEnabled, error]);
 
   if (!isOpen) {
     return null;

--- a/src/components/modals/CameraStreamModal.tsx
+++ b/src/components/modals/CameraStreamModal.tsx
@@ -168,8 +168,13 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
 
   const cleanupPlayer = useCallback(() => {
     abortStreamSession();
-    audioBoostRef.current?.release();
-    audioBoostRef.current = null;
+    if (audioBoostRef.current) {
+      debugLog('camera', 'cleanupPlayer releaseVideoAudioBoost', {
+        contextState: audioBoostRef.current.contextState,
+      });
+      audioBoostRef.current.release();
+      audioBoostRef.current = null;
+    }
     if (hlsRef.current) {
       hlsRef.current.destroy();
       hlsRef.current = null;
@@ -609,24 +614,73 @@ export const CameraStreamModal: React.FC<CameraStreamModalProps> = ({
   // Do NOT depend on cameraDevice — privacy polls refresh it every ~20s and would re-run
   // this effect; tearing down MediaElementSource then re-attaching throws InvalidStateError
   // and can unmount the entire React tree (blank app, only CSS background left).
+  //
+  // CRITICAL: createMediaElementSource must run AFTER the element has a MediaStream.
+  // Attaching on an empty <video> and then switching srcObject (Goloom combined stream)
+  // often yields silent playback in Chromium/Electron even though the audio track is live.
   useEffect(() => {
     if (!isOpen || !streamProtocol) return;
     const video = videoRef.current;
     if (!video) return;
+    if (!isYandexCameraDevice(cameraDeviceRef.current)) return;
 
-    video.muted = false;
-    video.volume = 1;
-    if (isYandexCameraDevice(cameraDeviceRef.current)) {
-      debugLog('camera', 'attachVideoAudioBoost', { streamProtocol, videoWidth: video.videoWidth });
+    const applyBoost = (reason: string) => {
+      const stream = video.srcObject;
+      if (stream instanceof MediaStream) {
+        const liveAudio = stream.getAudioTracks().filter((t) => t.readyState === 'live');
+        if (liveAudio.length === 0) {
+          debugLog('camera', 'skip attachVideoAudioBoost — waiting for audio track', {
+            reason,
+            videoTracks: stream.getVideoTracks().length,
+          });
+          return;
+        }
+      } else if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+        debugLog('camera', 'skip attachVideoAudioBoost — no media yet', {
+          reason,
+          readyState: video.readyState,
+        });
+        return;
+      }
+
+      video.muted = false;
+      video.volume = 1;
       try {
-        audioBoostRef.current = attachVideoAudioBoost(video);
+        const boost = attachVideoAudioBoost(video);
+        audioBoostRef.current = boost;
+        debugLog('camera', 'attachVideoAudioBoost', {
+          reason,
+          streamProtocol,
+          videoWidth: video.videoWidth,
+          contextState: boost.contextState,
+          paused: video.paused,
+          audioTracks: stream instanceof MediaStream
+            ? stream.getAudioTracks().map((t) => ({
+              id: t.id,
+              enabled: t.enabled,
+              muted: t.muted,
+              readyState: t.readyState,
+            }))
+            : null,
+        });
+        boost.resume();
       } catch (err) {
         debugWarn('camera', 'attachVideoAudioBoost failed', err);
       }
+    };
+
+    const onPlaying = () => applyBoost('playing');
+    video.addEventListener('playing', onPlaying);
+    // If playback already started before this effect ran, attach immediately.
+    if (!video.paused && video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+      applyBoost('effect-already-playing');
     }
 
     return () => {
-      debugLog('camera', 'releaseVideoAudioBoost');
+      video.removeEventListener('playing', onPlaying);
+      debugLog('camera', 'releaseVideoAudioBoost', {
+        contextState: audioBoostRef.current?.contextState,
+      });
       audioBoostRef.current?.release();
       audioBoostRef.current = null;
     };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { debugError, debugLog, refreshDebugFlags } from './utils/debugLog';
+
+refreshDebugFlags();
+debugLog('react', 'renderer boot', { href: window.location.href });
+
+window.addEventListener('error', (event) => {
+  debugError('react', 'window.error', event.message, event.filename, event.lineno, event.error);
+});
+
+window.addEventListener('unhandledrejection', (event) => {
+  debugError('react', 'unhandledrejection', event.reason);
+});
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -14,3 +26,7 @@ root.render(
     <App />
   // </React.StrictMode>
 );
+
+debugLog('react', 'root.render called', {
+  rootChildren: rootElement.childElementCount,
+});

--- a/src/utils/debugLog.ts
+++ b/src/utils/debugLog.ts
@@ -1,0 +1,52 @@
+/**
+ * Debug logging for renderer (camera / app lifecycle).
+ * Enabled automatically in Vite DEV, or via localStorage DEBUG=1 / DEBUG=camera,app
+ */
+const isViteDev = Boolean(import.meta.env?.DEV);
+
+const readFlags = (): Set<string> => {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage?.getItem('DEBUG') ?? '';
+    if (!raw) return new Set();
+    if (raw === '1' || raw === '*' || raw.toLowerCase() === 'true') {
+      return new Set(['app', 'camera', 'goloom', 'react']);
+    }
+    return new Set(
+      raw
+        .split(/[,+\s]+/)
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean),
+    );
+  } catch {
+    return new Set();
+  }
+};
+
+let flags = readFlags();
+
+export const refreshDebugFlags = (): void => {
+  flags = readFlags();
+};
+
+export const isDebugEnabled = (channel: string): boolean => {
+  if (isViteDev) return true;
+  return flags.has(channel.toLowerCase()) || flags.has('*');
+};
+
+export const debugLog = (channel: string, ...args: unknown[]): void => {
+  if (!isDebugEnabled(channel)) return;
+  const tag = `[Debug:${channel}]`;
+  console.log(tag, ...args);
+};
+
+export const debugWarn = (channel: string, ...args: unknown[]): void => {
+  if (!isDebugEnabled(channel)) return;
+  console.warn(`[Debug:${channel}]`, ...args);
+};
+
+export const debugError = (channel: string, ...args: unknown[]): void => {
+  // Errors always surface in DEV; in prod only when DEBUG flags set
+  if (!isViteDev && !isDebugEnabled(channel)) return;
+  console.error(`[Debug:${channel}]`, ...args);
+};

--- a/src/utils/debugLog.ts
+++ b/src/utils/debugLog.ts
@@ -34,10 +34,21 @@ export const isDebugEnabled = (channel: string): boolean => {
   return flags.has(channel.toLowerCase()) || flags.has('*');
 };
 
+const formatDebugArg = (arg: unknown): unknown => {
+  if (arg !== null && typeof arg === 'object' && !(arg instanceof Error) && !(arg instanceof Event)) {
+    try {
+      return JSON.stringify(arg);
+    } catch {
+      return arg;
+    }
+  }
+  return arg;
+};
+
 export const debugLog = (channel: string, ...args: unknown[]): void => {
   if (!isDebugEnabled(channel)) return;
   const tag = `[Debug:${channel}]`;
-  console.log(tag, ...args);
+  console.log(tag, ...args.map(formatDebugArg));
 };
 
 export const debugWarn = (channel: string, ...args: unknown[]): void => {

--- a/src/utils/videoAudioBoost.ts
+++ b/src/utils/videoAudioBoost.ts
@@ -3,7 +3,10 @@ export const CAMERA_AUDIO_GAIN = 4.0;
 
 export interface VideoAudioBoost {
   setGain: (value: number) => void;
+  /** Restore boost gain and ensure AudioContext is running. */
+  resume: () => void;
   release: () => void;
+  readonly contextState: AudioContextState;
 }
 
 const attached = new WeakMap<HTMLVideoElement, VideoAudioBoost>();
@@ -15,6 +18,8 @@ const attached = new WeakMap<HTMLVideoElement, VideoAudioBoost>();
  * IMPORTANT: HTMLMediaElement may only have createMediaElementSource() called once
  * for its lifetime. Releasing must NOT tear down the MediaElementSource graph, or the
  * next attach on the same <video> throws InvalidStateError and can crash the React tree.
+ * Also do NOT suspend the AudioContext on release — effect cleanup + re-attach would leave
+ * playback silent (setGain alone does not wake a suspended context).
  */
 export const attachVideoAudioBoost = (
   video: HTMLVideoElement,
@@ -22,6 +27,7 @@ export const attachVideoAudioBoost = (
 ): VideoAudioBoost => {
   const existing = attached.get(video);
   if (existing) {
+    existing.resume();
     existing.setGain(initialGain);
     return existing;
   }
@@ -33,18 +39,25 @@ export const attachVideoAudioBoost = (
   source.connect(gainNode);
   gainNode.connect(ctx.destination);
 
-  const resume = () => { void ctx.resume(); };
-  video.addEventListener('play', resume);
+  const resumeCtx = () => { void ctx.resume(); };
+  video.addEventListener('play', resumeCtx);
   void ctx.resume();
 
   const boost: VideoAudioBoost = {
-    setGain: (value) => { gainNode.gain.value = value; },
+    get contextState() { return ctx.state; },
+    setGain: (value) => {
+      gainNode.gain.value = value;
+      void ctx.resume();
+    },
+    resume: () => {
+      void ctx.resume();
+    },
     release: () => {
-      video.removeEventListener('play', resume);
-      // Reset audible boost but keep MediaElementSource + WeakMap entry.
-      // createMediaElementSource cannot be called again on this element.
+      // Keep MediaElementSource + WeakMap entry + play→resume listener.
+      // Only drop the boost gain; never disconnect/close/suspend the graph.
+      // (suspend() previously left the camera silent after cleanupPlayer:
+      //  boost effect did not re-run, so the context never resumed.)
       gainNode.gain.value = 1;
-      void ctx.suspend();
     },
   };
 

--- a/src/utils/videoAudioBoost.ts
+++ b/src/utils/videoAudioBoost.ts
@@ -11,6 +11,10 @@ const attached = new WeakMap<HTMLVideoElement, VideoAudioBoost>();
 /**
  * Route <video> audio through a GainNode so volume can exceed HTMLMediaElement's 1.0 cap.
  * Safe to call repeatedly on the same element — createMediaElementSource runs once.
+ *
+ * IMPORTANT: HTMLMediaElement may only have createMediaElementSource() called once
+ * for its lifetime. Releasing must NOT tear down the MediaElementSource graph, or the
+ * next attach on the same <video> throws InvalidStateError and can crash the React tree.
  */
 export const attachVideoAudioBoost = (
   video: HTMLVideoElement,
@@ -37,12 +41,10 @@ export const attachVideoAudioBoost = (
     setGain: (value) => { gainNode.gain.value = value; },
     release: () => {
       video.removeEventListener('play', resume);
-      attached.delete(video);
-      try {
-        source.disconnect();
-        gainNode.disconnect();
-      } catch { /* ignore */ }
-      void ctx.close();
+      // Reset audible boost but keep MediaElementSource + WeakMap entry.
+      // createMediaElementSource cannot be called again on this element.
+      gainNode.gain.value = 1;
+      void ctx.suspend();
     },
   };
 


### PR DESCRIPTION
## Кратко
- Исправлено исчезновение всего интерфейса после открытия камеры: больше не пересоздаём `createMediaElementSource` / не рвём Web Audio graph при опросах privacy.
- Восстановлен звук стрима: audio boost вешается только после появления live audio track; `AudioContext` не уходит в suspend при release.
- Бейдж микрофона на карточке камеры привязан к `camera_hw_mute` (аппаратный mute), а не к privacy/`*mute*`; добавлено debug-логирование жизненного цикла камеры/приложения.

## План проверки
- [x] Открыть стрим Yandex-камеры и держать 60+ секунд (хотя бы один privacy poll) — UI не должен пропадать
- [x] При включённом аппаратном микрофоне на камере звук в стриме слышен
- [x] При `camera_hw_mute: hw_mute_enabled` бейдж MicOff и tooltip про аппаратный mute; в стриме нет звука с микрофона
- [x] Включить микрофон кнопкой на камере, открыть стрим снова — звук появляется
- [x] В DevTools/терминале есть `[Debug:camera]`, нет `InvalidStateError` от `MediaElementSource`